### PR TITLE
feat: add base classes entrypoints

### DIFF
--- a/src/color-picker-hex.ts
+++ b/src/color-picker-hex.ts
@@ -1,15 +1,4 @@
-import type { ColorModel } from './lib/types';
-import { ColorPicker } from './lib/components/color-picker.js';
-import { hexToHsv, hsvToHex } from './lib/utils/convert.js';
-import { equalHex } from './lib/utils/compare.js';
-
-const colorModel: ColorModel<string> = {
-  defaultColor: '#000',
-  toHsv: hexToHsv,
-  fromHsv: hsvToHex,
-  equal: equalHex,
-  fromAttr: (color) => color
-};
+import { HexBase } from './lib/entrypoints/hex.js';
 
 /**
  * A color picker custom element that uses HEX format.
@@ -25,11 +14,7 @@ const colorModel: ColorModel<string> = {
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  */
-export class ColorPickerHex extends ColorPicker<string> {
-  protected get colorModel(): ColorModel<string> {
-    return colorModel;
-  }
-}
+export class ColorPickerHex extends HexBase {}
 
 customElements.define('color-picker-hex', ColorPickerHex);
 

--- a/src/color-picker-hsl-string.ts
+++ b/src/color-picker-hsl-string.ts
@@ -1,15 +1,4 @@
-import type { ColorModel } from './lib/types';
-import { ColorPicker } from './lib/components/color-picker.js';
-import { hslStringToHsv, hsvToHslString } from './lib/utils/convert.js';
-import { equalColorString } from './lib/utils/compare.js';
-
-const colorModel: ColorModel<string> = {
-  defaultColor: 'hsl(0, 0%, 0%)',
-  toHsv: hslStringToHsv,
-  fromHsv: hsvToHslString,
-  equal: equalColorString,
-  fromAttr: (color) => color
-};
+import { HslStringBase } from './lib/entrypoints/hsl-string.js';
 
 /**
  * A color picker custom element that uses HSL string format.
@@ -25,11 +14,7 @@ const colorModel: ColorModel<string> = {
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  */
-export class ColorPickerHslString extends ColorPicker<string> {
-  protected get colorModel(): ColorModel<string> {
-    return colorModel;
-  }
-}
+export class ColorPickerHslString extends HslStringBase {}
 
 customElements.define('color-picker-hsl-string', ColorPickerHslString);
 

--- a/src/color-picker-hsl.ts
+++ b/src/color-picker-hsl.ts
@@ -1,17 +1,5 @@
-import type { ColorModel, HSL } from './lib/types';
-import { ColorPicker } from './lib/components/color-picker.js';
-import { hslToHsv, hsvToHsl } from './lib/utils/convert.js';
-import { equalColorObjects } from './lib/utils/compare.js';
-
-export { HSL };
-
-const colorModel: ColorModel<HSL> = {
-  defaultColor: { h: 0, s: 0, l: 0 },
-  toHsv: hslToHsv,
-  fromHsv: hsvToHsl,
-  equal: equalColorObjects,
-  fromAttr: (color) => JSON.parse(color)
-};
+import { HslBase } from './lib/entrypoints/hsl.js';
+export type { HSL } from './lib/types';
 
 /**
  * A color picker custom element that uses HSL object format.
@@ -27,11 +15,7 @@ const colorModel: ColorModel<HSL> = {
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  */
-export class ColorPickerHsl extends ColorPicker<HSL> {
-  protected get colorModel(): ColorModel<HSL> {
-    return colorModel;
-  }
-}
+export class ColorPickerHsl extends HslBase {}
 
 customElements.define('color-picker-hsl', ColorPickerHsl);
 

--- a/src/color-picker-hsv.ts
+++ b/src/color-picker-hsv.ts
@@ -1,16 +1,5 @@
-import type { ColorModel, HSV } from './lib/types';
-import { ColorPicker } from './lib/components/color-picker.js';
-import { equalColorObjects } from './lib/utils/compare.js';
-
-export { HSV };
-
-const colorModel: ColorModel<HSV> = {
-  defaultColor: { h: 0, s: 0, v: 0 },
-  toHsv: (hsv) => hsv,
-  fromHsv: (hsv) => hsv,
-  equal: equalColorObjects,
-  fromAttr: (color) => JSON.parse(color)
-};
+import { HsvBase } from './lib/entrypoints/hsv.js';
+export type { HSV } from './lib/types';
 
 /**
  * A color picker custom element that uses HSV object format.
@@ -26,11 +15,7 @@ const colorModel: ColorModel<HSV> = {
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  */
-export class ColorPickerHsv extends ColorPicker<HSV> {
-  protected get colorModel(): ColorModel<HSV> {
-    return colorModel;
-  }
-}
+export class ColorPickerHsv extends HsvBase {}
 
 customElements.define('color-picker-hsv', ColorPickerHsv);
 

--- a/src/color-picker-rgb-string.ts
+++ b/src/color-picker-rgb-string.ts
@@ -1,15 +1,4 @@
-import type { ColorModel } from './lib/types';
-import { ColorPicker } from './lib/components/color-picker.js';
-import { hsvToRgbString, rgbStringToHsv } from './lib/utils/convert.js';
-import { equalColorString } from './lib/utils/compare.js';
-
-const colorModel: ColorModel<string> = {
-  defaultColor: 'rgb(0, 0, 0)',
-  toHsv: rgbStringToHsv,
-  fromHsv: hsvToRgbString,
-  equal: equalColorString,
-  fromAttr: (color) => color
-};
+import { RgbStringBase } from './lib/entrypoints/rgb-string.js';
 
 /**
  * A color picker custom element that uses RGB string format.
@@ -25,11 +14,7 @@ const colorModel: ColorModel<string> = {
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  */
-export class ColorPickerRgbString extends ColorPicker<string> {
-  protected get colorModel(): ColorModel<string> {
-    return colorModel;
-  }
-}
+export class ColorPickerRgbString extends RgbStringBase {}
 
 customElements.define('color-picker-rgb-string', ColorPickerRgbString);
 

--- a/src/color-picker-rgb.ts
+++ b/src/color-picker-rgb.ts
@@ -1,17 +1,5 @@
-import type { ColorModel, RGB } from './lib/types';
-import { ColorPicker } from './lib/components/color-picker.js';
-import { hsvToRgb, rgbToHsv } from './lib/utils/convert.js';
-import { equalColorObjects } from './lib/utils/compare.js';
-
-export { RGB };
-
-const colorModel: ColorModel<RGB> = {
-  defaultColor: { r: 0, g: 0, b: 0 },
-  toHsv: rgbToHsv,
-  fromHsv: hsvToRgb,
-  equal: equalColorObjects,
-  fromAttr: (color) => JSON.parse(color)
-};
+import { RgbBase } from './lib/entrypoints/rgb.js';
+export type { RGB } from './lib/types';
 
 /**
  * A color picker custom element that uses RGB object format.
@@ -27,11 +15,7 @@ const colorModel: ColorModel<RGB> = {
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  */
-export class ColorPickerRgb extends ColorPicker<RGB> {
-  protected get colorModel(): ColorModel<RGB> {
-    return colorModel;
-  }
-}
+export class ColorPickerRgb extends RgbBase {}
 
 customElements.define('color-picker-rgb', ColorPickerRgb);
 

--- a/src/hex-input.ts
+++ b/src/hex-input.ts
@@ -1,7 +1,4 @@
-import { validHex } from './lib/utils/validate.js';
-
-// Escapes all non-hexadecimal characters including "#"
-const escape = (hex: string) => hex.replace(/([^0-9A-F]+)/gi, '');
+import { HexInputBase } from './lib/entrypoints/hex-input.js';
 
 /**
  * A color picker custom element that uses HEX format.
@@ -12,78 +9,7 @@ const escape = (hex: string) => hex.replace(/([^0-9A-F]+)/gi, '');
  *
  * @fires color-changed - Event fired when color is changed.
  */
-export class HexInput extends HTMLElement {
-  static get observedAttributes(): string[] {
-    return ['color'];
-  }
-
-  private _color!: string;
-
-  private _oldColor!: string;
-
-  private _input!: HTMLInputElement;
-
-  get color(): string {
-    return this._color;
-  }
-
-  set color(hex: string) {
-    this._color = hex;
-    this._input.value = hex == null || hex == '' ? '' : escape(hex);
-  }
-
-  constructor() {
-    super();
-    let input = this.querySelector('input');
-    if (!input) {
-      input = document.createElement('input');
-      input.setAttribute('spellcheck', 'false');
-      input.setAttribute('maxlength', '6');
-      this.appendChild(input);
-    }
-    input.addEventListener('input', this);
-    input.addEventListener('blur', this);
-    this._input = input;
-  }
-
-  connectedCallback(): void {
-    // A user may set a property on an _instance_ of an element,
-    // before its prototype has been connected to this class.
-    // If so, we need to run it through the proper class setter.
-    if (this.hasOwnProperty('color')) {
-      const value = this.color;
-      delete this['color' as keyof this];
-      this.color = value;
-    } else if (this.color == null) {
-      this.color = this.getAttribute('color') || '';
-    }
-  }
-
-  handleEvent(event: Event): void {
-    const target = event.target as HTMLInputElement;
-    const { value } = target;
-    switch (event.type) {
-      case 'input':
-        const hex = escape(value);
-        this._oldColor = this.color;
-        if (validHex(hex)) {
-          this.color = hex;
-          this.dispatchEvent(new CustomEvent('color-changed', { detail: { value: '#' + hex } }));
-        }
-        break;
-      case 'blur':
-        if (!validHex(value)) {
-          this.color = this._oldColor;
-        }
-    }
-  }
-
-  attributeChangedCallback(_attr: string, _oldVal: string, newVal: string): void {
-    if (this.color !== newVal) {
-      this.color = newVal;
-    }
-  }
-}
+export class HexInput extends HexInputBase {}
 
 customElements.define('hex-input', HexInput);
 

--- a/src/lib/entrypoints/hex-input.ts
+++ b/src/lib/entrypoints/hex-input.ts
@@ -1,0 +1,77 @@
+import { validHex } from '../utils/validate.js';
+
+// Escapes all non-hexadecimal characters including "#"
+const escape = (hex: string) => hex.replace(/([^0-9A-F]+)/gi, '');
+
+export class HexInputBase extends HTMLElement {
+  static get observedAttributes(): string[] {
+    return ['color'];
+  }
+
+  private _color!: string;
+
+  private _oldColor!: string;
+
+  private _input!: HTMLInputElement;
+
+  get color(): string {
+    return this._color;
+  }
+
+  set color(hex: string) {
+    this._color = hex;
+    this._input.value = hex == null || hex == '' ? '' : escape(hex);
+  }
+
+  constructor() {
+    super();
+    let input = this.querySelector('input');
+    if (!input) {
+      input = document.createElement('input');
+      input.setAttribute('spellcheck', 'false');
+      input.setAttribute('maxlength', '6');
+      this.appendChild(input);
+    }
+    input.addEventListener('input', this);
+    input.addEventListener('blur', this);
+    this._input = input;
+  }
+
+  connectedCallback(): void {
+    // A user may set a property on an _instance_ of an element,
+    // before its prototype has been connected to this class.
+    // If so, we need to run it through the proper class setter.
+    if (this.hasOwnProperty('color')) {
+      const value = this.color;
+      delete this['color' as keyof this];
+      this.color = value;
+    } else if (this.color == null) {
+      this.color = this.getAttribute('color') || '';
+    }
+  }
+
+  handleEvent(event: Event): void {
+    const target = event.target as HTMLInputElement;
+    const { value } = target;
+    switch (event.type) {
+      case 'input':
+        const hex = escape(value);
+        this._oldColor = this.color;
+        if (validHex(hex)) {
+          this.color = hex;
+          this.dispatchEvent(new CustomEvent('color-changed', { detail: { value: '#' + hex } }));
+        }
+        break;
+      case 'blur':
+        if (!validHex(value)) {
+          this.color = this._oldColor;
+        }
+    }
+  }
+
+  attributeChangedCallback(_attr: string, _oldVal: string, newVal: string): void {
+    if (this.color !== newVal) {
+      this.color = newVal;
+    }
+  }
+}

--- a/src/lib/entrypoints/hex.ts
+++ b/src/lib/entrypoints/hex.ts
@@ -1,0 +1,18 @@
+import type { ColorModel } from '../types';
+import { ColorPicker } from '../components/color-picker.js';
+import { hexToHsv, hsvToHex } from '../utils/convert.js';
+import { equalHex } from '../utils/compare.js';
+
+const colorModel: ColorModel<string> = {
+  defaultColor: '#000',
+  toHsv: hexToHsv,
+  fromHsv: hsvToHex,
+  equal: equalHex,
+  fromAttr: (color) => color
+};
+
+export class HexBase extends ColorPicker<string> {
+  protected get colorModel(): ColorModel<string> {
+    return colorModel;
+  }
+}

--- a/src/lib/entrypoints/hsl-string.ts
+++ b/src/lib/entrypoints/hsl-string.ts
@@ -1,0 +1,18 @@
+import type { ColorModel } from '../types';
+import { ColorPicker } from '../components/color-picker.js';
+import { hslStringToHsv, hsvToHslString } from '../utils/convert.js';
+import { equalColorString } from '../utils/compare.js';
+
+const colorModel: ColorModel<string> = {
+  defaultColor: 'hsl(0, 0%, 0%)',
+  toHsv: hslStringToHsv,
+  fromHsv: hsvToHslString,
+  equal: equalColorString,
+  fromAttr: (color) => color
+};
+
+export class HslStringBase extends ColorPicker<string> {
+  protected get colorModel(): ColorModel<string> {
+    return colorModel;
+  }
+}

--- a/src/lib/entrypoints/hsl.ts
+++ b/src/lib/entrypoints/hsl.ts
@@ -1,0 +1,18 @@
+import type { ColorModel, HSL } from '../types';
+import { ColorPicker } from '../components/color-picker.js';
+import { hslToHsv, hsvToHsl } from '../utils/convert.js';
+import { equalColorObjects } from '../utils/compare.js';
+
+const colorModel: ColorModel<HSL> = {
+  defaultColor: { h: 0, s: 0, l: 0 },
+  toHsv: hslToHsv,
+  fromHsv: hsvToHsl,
+  equal: equalColorObjects,
+  fromAttr: (color) => JSON.parse(color)
+};
+
+export class HslBase extends ColorPicker<HSL> {
+  protected get colorModel(): ColorModel<HSL> {
+    return colorModel;
+  }
+}

--- a/src/lib/entrypoints/hsv.ts
+++ b/src/lib/entrypoints/hsv.ts
@@ -1,0 +1,17 @@
+import type { ColorModel, HSV } from '../types';
+import { ColorPicker } from '../components/color-picker.js';
+import { equalColorObjects } from '../utils/compare.js';
+
+const colorModel: ColorModel<HSV> = {
+  defaultColor: { h: 0, s: 0, v: 0 },
+  toHsv: (hsv) => hsv,
+  fromHsv: (hsv) => hsv,
+  equal: equalColorObjects,
+  fromAttr: (color) => JSON.parse(color)
+};
+
+export class HsvBase extends ColorPicker<HSV> {
+  protected get colorModel(): ColorModel<HSV> {
+    return colorModel;
+  }
+}

--- a/src/lib/entrypoints/rgb-string.ts
+++ b/src/lib/entrypoints/rgb-string.ts
@@ -1,0 +1,18 @@
+import type { ColorModel } from '../types';
+import { ColorPicker } from '../components/color-picker.js';
+import { hsvToRgbString, rgbStringToHsv } from '../utils/convert.js';
+import { equalColorString } from '../utils/compare.js';
+
+const colorModel: ColorModel<string> = {
+  defaultColor: 'rgb(0, 0, 0)',
+  toHsv: rgbStringToHsv,
+  fromHsv: hsvToRgbString,
+  equal: equalColorString,
+  fromAttr: (color) => color
+};
+
+export class RgbStringBase extends ColorPicker<string> {
+  protected get colorModel(): ColorModel<string> {
+    return colorModel;
+  }
+}

--- a/src/lib/entrypoints/rgb.ts
+++ b/src/lib/entrypoints/rgb.ts
@@ -1,0 +1,18 @@
+import type { ColorModel, RGB } from '../types';
+import { ColorPicker } from '../components/color-picker.js';
+import { hsvToRgb, rgbToHsv } from '../utils/convert.js';
+import { equalColorObjects } from '../utils/compare.js';
+
+const colorModel: ColorModel<RGB> = {
+  defaultColor: { r: 0, g: 0, b: 0 },
+  toHsv: rgbToHsv,
+  fromHsv: hsvToRgb,
+  equal: equalColorObjects,
+  fromAttr: (color) => JSON.parse(color)
+};
+
+export class RgbBase extends ColorPicker<RGB> {
+  protected get colorModel(): ColorModel<RGB> {
+    return colorModel;
+  }
+}


### PR DESCRIPTION
Fixes #1 

From now on, it will be possible to import base classes, extend them and register custom elements.

Note that internal elements (`color-hue` and `color-saturation`) are still registered. 
I think we could at least use a different prefix, e.g. `vc-` ("vanilla-colorful") for those.