### PR TITLE
refactor!: rename components and types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,10 @@
 /test/**/*.js
 /test/**/*.js.map
 /src/lib/styles/*.ts
-color-picker-*.js
-hex-input.js
+hex-*.js
+hsl-*.js
+hsv-*.js
+rgb-*.js
 *.d.ts
 *.map
 custom-elements.json

--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ Or use one of the following content delivery networks:
 ## Usage
 
 ```html
-<color-picker-hex color="#1e88e5"></color-picker-hex>
+<hex-color-picker color="#1e88e5"></hex-color-picker>
 <script type="module">
   import 'vanilla-colorful';
 
-  const picker = document.querySelector('color-picker-gex');
+  const picker = document.querySelector('hex-color-picker');
   picker.addEventListener('color-changed', (event) => {
     const newColor = event.detail.value;
   });
@@ -85,20 +85,21 @@ you need another color model, we provide 5 additional color picker bundles.
 
 | File to import                 | HTML element                | Value example                |
 | ------------------------------ | --------------------------- | ---------------------------- |
-| `"color-picker-rgb.js"`        | `<color-picker-rgb>`        | `{ r: 255, g: 255, b: 255 }` |
-| `"color-picker-rgb-string.js"` | `<color-picker-rgb-string>` | `"rgb(255, 255, 255)"`       |
-| `"color-picker-hsl.js"`        | `<color-picker-hsl>`        | `{ h: 0, s: 0, l: 100 }`     |
-| `"color-picker-hsl-string.js"` | `<color-picker-hsl-string>` | `"hsl(0, 0%, 100%)"`         |
-| `"color-picker-hsv.js"`        | `<color-picker-hsv>`        | `{ h: 0, s: 0, v: 100 }`     |
+| `"hex-color-picker.js"`        | `<hex-color-picker>`        | `"#ffffff"`                  |
+| `"hsl-color-picker.js"`        | `<hsl-color-picker>`        | `{ h: 0, s: 0, l: 100 }`     |
+| `"hsl-string-color-picker.js"` | `<hsl-string-color-picker>` | `"hsl(0, 0%, 100%)"`         |
+| `"hsv-color-picker.js"`        | `<hsv-color-picker>`        | `{ h: 0, s: 0, v: 100 }`     |
+| `"rgb-color-picker.js"`        | `<rgb-color-picker>`        | `{ r: 255, g: 255, b: 255 }` |
+| `"rgb-string-color-picker.js"` | `<rgb-string-color-picker>` | `"rgb(255, 255, 255)"`       |
 
 #### Code example
 
 ```html
-<color-picker-rgb></color-picker-rgb>
+<rgb-color-picker></rgb-color-picker>
 <script type="module">
-  import 'vanilla-colorful/color-picker-rgb.js';
+  import 'vanilla-colorful/rgb-color-picker.js';
 
-  const picker = document.querySelector('color-picker-rgb');
+  const picker = document.querySelector('rgb-color-picker');
   picker.color = { r: 50, g: 100, b: 150 };
 </script>
 ```
@@ -111,25 +112,25 @@ you need another color model, we provide 5 additional color picker bundles.
 allowing to override the default styles:
 
 ```css
-color-picker-hex {
+hex-color-picker {
   height: 250px;
 }
 
-color-picker-hex::part(saturation) {
+hex-color-picker::part(saturation) {
   bottom: 30px;
   border-radius: 3px 3px 0 0;
 }
 
-color-picker-hex::part(hue) {
+hex-color-picker::part(hue) {
   height: 30px;
   border-radius: 0 0 3px 3px;
 }
 
-color-picker-hex::part(saturation-pointer) {
+hex-color-picker::part(saturation-pointer) {
   border-radius: 5px;
 }
 
-color-picker-hex::part(hue-pointer) {
+hex-color-picker::part(hue-pointer) {
   border-radius: 2px;
   width: 15px;
   height: inherit;
@@ -178,9 +179,9 @@ the element you're using, you can also import the type that is associated with t
 For example, if you're using our HSL color picker component, you can also import the `HSL` type.
 
 ```ts
-import type { HSL } from 'vanilla-colorful/color-picker-hsl';
+import type { HslColor } from 'vanilla-colorful/hsl-color-picker';
 
-const myHslValue: HSL = { h: 0, s: 0, l: 0 };
+const myHslValue: HslColor = { h: 0, s: 0, l: 0 };
 ```
 
 All the included custom elements are compatible with [lit-analyzer](https://www.npmjs.com/package/lit-analyzer) and

--- a/demo/index.html
+++ b/demo/index.html
@@ -14,7 +14,7 @@
     <div class="wrapper" style="color: var(--contrast, #fff)">
       <header class="header">
         <div class="demo">
-          <color-picker-hex color="#1e88e5"></color-picker-hex>
+          <hex-color-picker color="#1e88e5"></hex-color-picker>
           <div class="field">
             <hex-input></hex-input>
           </div>
@@ -49,7 +49,7 @@
     </div>
 
     <script type="module">
-      import '../color-picker-hex.js';
+      import '../hex-color-picker.js';
       import '../hex-input.js';
       import { hexToRgb } from '../lib/utils/convert.js';
       import { setFaviconColor } from './favicon.js';
@@ -57,7 +57,7 @@
       // See http://www.w3.org/TR/AERT#color-contrast
       const getBrightness = ({ r, g, b }) => (r * 299 + g * 587 + b * 114) / 1000;
 
-      const picker = document.querySelector('color-picker-hex');
+      const picker = document.querySelector('hex-color-picker');
       const input = document.querySelector('hex-input');
 
       const defaultColor = picker.color;

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -22,7 +22,7 @@ body {
   flex-shrink: 0;
 }
 
-color-picker-hex {
+hex-color-picker {
   border-radius: 9px;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.2);
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A tiny framework agnostic color picker element for modern web apps",
   "author": "Serhii Kulykov <iamkulykov@gmail.com>",
   "license": "MIT",
-  "main": "color-picker-hex.js",
-  "module": "color-picker-hex.js",
+  "main": "hex-color-picker.js",
+  "module": "hex-color-picker.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-padawan/vanilla-colorful.git"
@@ -19,14 +19,22 @@
     "LICENSE",
     "README.md",
     "/lib",
-    "/color-*.d.ts",
-    "/color-*.d.ts.map",
-    "/color-*.js",
-    "/color-*.js.map",
-    "/hex-input.d.ts",
-    "/hex-input.d.ts.map",
-    "/hex-input.js",
-    "/hex-input.js.map",
+    "/hex-*.d.ts",
+    "/hex-*.d.ts.map",
+    "/hex-*.js",
+    "/hex-*.js.map",
+    "/hsl-*.d.ts",
+    "/hsl-*.d.ts.map",
+    "/hsl-*.js",
+    "/hsl-*.js.map",
+    "/hsv-*.d.ts",
+    "/hsv-*.d.ts.map",
+    "/hsv-*.js",
+    "/hsv-*.js.map",
+    "/rgb-*.d.ts",
+    "/rgb-*.d.ts.map",
+    "/rgb-*.js",
+    "/rgb-*.js.map",
     "custom-elements.json"
   ],
   "scripts": {
@@ -58,27 +66,27 @@
   },
   "size-limit": [
     {
-      "path": "color-picker-hex.js",
+      "path": "hex-color-picker.js",
       "limit": "2.2 KB"
     },
     {
-      "path": "color-picker-hsl.js",
+      "path": "hsl-color-picker.js",
       "limit": "2 KB"
     },
     {
-      "path": "color-picker-hsl-string.js",
+      "path": "hsl-string-color-picker.js",
       "limit": "2 KB"
     },
     {
-      "path": "color-picker-hsv.js",
+      "path": "hsv-color-picker.js",
       "limit": "2 KB"
     },
     {
-      "path": "color-picker-rgb.js",
+      "path": "rgb-color-picker.js",
       "limit": "2.1 KB"
     },
     {
-      "path": "color-picker-rgb-string.js",
+      "path": "rgb-string-color-picker.js",
       "limit": "2.1 KB"
     },
     {

--- a/src/hex-color-picker.ts
+++ b/src/hex-color-picker.ts
@@ -3,7 +3,7 @@ import { HexBase } from './lib/entrypoints/hex.js';
 /**
  * A color picker custom element that uses HEX format.
  *
- * @element color-picker-hex
+ * @element hex-color-picker
  *
  * @prop {string} color - Selected color in HEX format.
  *
@@ -14,12 +14,12 @@ import { HexBase } from './lib/entrypoints/hex.js';
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  */
-export class ColorPickerHex extends HexBase {}
+export class HexColorPicker extends HexBase {}
 
-customElements.define('color-picker-hex', ColorPickerHex);
+customElements.define('hex-color-picker', HexColorPicker);
 
 declare global {
   interface HTMLElementTagNameMap {
-    'color-picker-hex': ColorPickerHex;
+    'hex-color-picker': HexColorPicker;
   }
 }

--- a/src/hsl-color-picker.ts
+++ b/src/hsl-color-picker.ts
@@ -1,12 +1,12 @@
 import { HslBase } from './lib/entrypoints/hsl.js';
-export type { HSL } from './lib/types';
+export type { HslColor } from './lib/types';
 
 /**
  * A color picker custom element that uses HSL object format.
  *
- * @element color-picker-hsl
+ * @element hsl-color-picker
  *
- * @prop {HSL} color - Selected color in HSL object format.
+ * @prop {HslColor} color - Selected color in HSL object format.
  *
  * @fires color-changed - Event fired when color property changes.
  *
@@ -15,12 +15,12 @@ export type { HSL } from './lib/types';
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  */
-export class ColorPickerHsl extends HslBase {}
+export class HslColorPicker extends HslBase {}
 
-customElements.define('color-picker-hsl', ColorPickerHsl);
+customElements.define('hsl-color-picker', HslColorPicker);
 
 declare global {
   interface HTMLElementTagNameMap {
-    'color-picker-hsl': ColorPickerHsl;
+    'hsl-color-picker': HslColorPicker;
   }
 }

--- a/src/hsl-string-color-picker.ts
+++ b/src/hsl-string-color-picker.ts
@@ -3,7 +3,7 @@ import { HslStringBase } from './lib/entrypoints/hsl-string.js';
 /**
  * A color picker custom element that uses HSL string format.
  *
- * @element color-picker-hsl-string
+ * @element hsl-string-color-picker
  *
  * @prop {string} color - Selected color in HSL string format.
  *
@@ -14,12 +14,12 @@ import { HslStringBase } from './lib/entrypoints/hsl-string.js';
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  */
-export class ColorPickerHslString extends HslStringBase {}
+export class HslStringColorPicker extends HslStringBase {}
 
-customElements.define('color-picker-hsl-string', ColorPickerHslString);
+customElements.define('hsl-string-color-picker', HslStringColorPicker);
 
 declare global {
   interface HTMLElementTagNameMap {
-    'color-picker-hsl-string': ColorPickerHslString;
+    'hsl-string-color-picker': HslStringColorPicker;
   }
 }

--- a/src/hsv-color-picker.ts
+++ b/src/hsv-color-picker.ts
@@ -1,12 +1,12 @@
 import { HsvBase } from './lib/entrypoints/hsv.js';
-export type { HSV } from './lib/types';
+export type { HsvColor } from './lib/types';
 
 /**
  * A color picker custom element that uses HSV object format.
  *
- * @element color-picker-hsv
+ * @element hsv-color-picker
  *
- * @prop {HSV} color - Selected color in HSV object format.
+ * @prop {HsvColor} color - Selected color in HSV object format.
  *
  * @fires color-changed - Event fired when color property changes.
  *
@@ -15,12 +15,12 @@ export type { HSV } from './lib/types';
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  */
-export class ColorPickerHsv extends HsvBase {}
+export class HsvColorPicker extends HsvBase {}
 
-customElements.define('color-picker-hsv', ColorPickerHsv);
+customElements.define('hsv-color-picker', HsvColorPicker);
 
 declare global {
   interface HTMLElementTagNameMap {
-    'color-picker-hsv': ColorPickerHsv;
+    'hsv-color-picker': HsvColorPicker;
   }
 }

--- a/src/lib/components/color-picker.ts
+++ b/src/lib/components/color-picker.ts
@@ -1,6 +1,6 @@
 import { equalColorObjects } from '../utils/compare.js';
 import { createTemplate, createRoot } from '../utils/dom.js';
-import type { AnyColor, ColorModel, HSV } from '../types';
+import type { AnyColor, ColorModel, HsvColor } from '../types';
 import type { Hue } from './hue.js';
 import type { Saturation } from './saturation.js';
 import './hue.js';
@@ -24,7 +24,7 @@ export abstract class ColorPicker<C extends AnyColor> extends HTMLElement {
 
   private _s!: Saturation;
 
-  private _hsv!: HSV;
+  private _hsv!: HsvColor;
 
   private _color!: C;
 
@@ -85,12 +85,12 @@ export abstract class ColorPicker<C extends AnyColor> extends HTMLElement {
     return this.color && this.colorModel.equal(color, this.color);
   }
 
-  private _render(hsv: HSV): void {
+  private _render(hsv: HsvColor): void {
     this._s.hsv = hsv;
     this._h.hue = hsv.h;
   }
 
-  private _change(color: C, hsv: HSV): void {
+  private _change(color: C, hsv: HsvColor): void {
     this._color = color;
     this._hsv = hsv;
     this.dispatchEvent(new CustomEvent('color-changed', { detail: { value: color } }));

--- a/src/lib/components/saturation.ts
+++ b/src/lib/components/saturation.ts
@@ -2,7 +2,7 @@ import { Interactive, Interaction } from './interactive.js';
 import { hsvToHslString } from '../utils/convert.js';
 import { createTemplate, createRoot } from '../utils/dom.js';
 import styles from '../styles/saturation.js';
-import type { HSV } from '../types';
+import type { HsvColor } from '../types';
 
 const template = createTemplate(`<style>${styles}</style>`);
 
@@ -20,7 +20,7 @@ export class Saturation extends Interactive {
     }
   }
 
-  set hsv(hsv: HSV) {
+  set hsv(hsv: HsvColor) {
     this.style.backgroundColor = hsvToHslString({ h: hsv.h, s: 100, v: 100 });
     this.setStyles({
       top: `${100 - hsv.v}%`,

--- a/src/lib/entrypoints/hsl.ts
+++ b/src/lib/entrypoints/hsl.ts
@@ -1,9 +1,9 @@
-import type { ColorModel, HSL } from '../types';
+import type { ColorModel, HslColor } from '../types';
 import { ColorPicker } from '../components/color-picker.js';
 import { hslToHsv, hsvToHsl } from '../utils/convert.js';
 import { equalColorObjects } from '../utils/compare.js';
 
-const colorModel: ColorModel<HSL> = {
+const colorModel: ColorModel<HslColor> = {
   defaultColor: { h: 0, s: 0, l: 0 },
   toHsv: hslToHsv,
   fromHsv: hsvToHsl,
@@ -11,8 +11,8 @@ const colorModel: ColorModel<HSL> = {
   fromAttr: (color) => JSON.parse(color)
 };
 
-export class HslBase extends ColorPicker<HSL> {
-  protected get colorModel(): ColorModel<HSL> {
+export class HslBase extends ColorPicker<HslColor> {
+  protected get colorModel(): ColorModel<HslColor> {
     return colorModel;
   }
 }

--- a/src/lib/entrypoints/hsv.ts
+++ b/src/lib/entrypoints/hsv.ts
@@ -1,8 +1,8 @@
-import type { ColorModel, HSV } from '../types';
+import type { ColorModel, HsvColor } from '../types';
 import { ColorPicker } from '../components/color-picker.js';
 import { equalColorObjects } from '../utils/compare.js';
 
-const colorModel: ColorModel<HSV> = {
+const colorModel: ColorModel<HsvColor> = {
   defaultColor: { h: 0, s: 0, v: 0 },
   toHsv: (hsv) => hsv,
   fromHsv: (hsv) => hsv,
@@ -10,8 +10,8 @@ const colorModel: ColorModel<HSV> = {
   fromAttr: (color) => JSON.parse(color)
 };
 
-export class HsvBase extends ColorPicker<HSV> {
-  protected get colorModel(): ColorModel<HSV> {
+export class HsvBase extends ColorPicker<HsvColor> {
+  protected get colorModel(): ColorModel<HsvColor> {
     return colorModel;
   }
 }

--- a/src/lib/entrypoints/rgb.ts
+++ b/src/lib/entrypoints/rgb.ts
@@ -1,9 +1,9 @@
-import type { ColorModel, RGB } from '../types';
+import type { ColorModel, RgbColor } from '../types';
 import { ColorPicker } from '../components/color-picker.js';
 import { hsvToRgb, rgbToHsv } from '../utils/convert.js';
 import { equalColorObjects } from '../utils/compare.js';
 
-const colorModel: ColorModel<RGB> = {
+const colorModel: ColorModel<RgbColor> = {
   defaultColor: { r: 0, g: 0, b: 0 },
   toHsv: rgbToHsv,
   fromHsv: hsvToRgb,
@@ -11,8 +11,8 @@ const colorModel: ColorModel<RGB> = {
   fromAttr: (color) => JSON.parse(color)
 };
 
-export class RgbBase extends ColorPicker<RGB> {
-  protected get colorModel(): ColorModel<RGB> {
+export class RgbBase extends ColorPicker<RgbColor> {
+  protected get colorModel(): ColorModel<RgbColor> {
     return colorModel;
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,27 +1,27 @@
-export interface RGB {
+export interface RgbColor {
   r: number;
   g: number;
   b: number;
 }
 
-export interface HSL {
+export interface HslColor {
   h: number;
   s: number;
   l: number;
 }
 
-export interface HSV {
+export interface HsvColor {
   h: number;
   s: number;
   v: number;
 }
 
-export type AnyColor = string | HSL | HSV | RGB;
+export type AnyColor = string | HslColor | HsvColor | RgbColor;
 
 export interface ColorModel<T extends AnyColor> {
   defaultColor: T;
-  toHsv: (color: T) => HSV;
-  fromHsv: (hsv: HSV) => T;
+  toHsv: (color: T) => HsvColor;
+  fromHsv: (hsv: HsvColor) => T;
   equal: (first: T, second: T) => boolean;
   fromAttr: (attr: string) => T;
 }

--- a/src/lib/utils/compare.ts
+++ b/src/lib/utils/compare.ts
@@ -1,7 +1,10 @@
-import type { HSL, HSV, RGB } from '../types';
+import type { HslColor, HsvColor, RgbColor } from '../types';
 import { hexToRgb } from './convert.js';
 
-export const equalColorObjects = (first: HSL | HSV | RGB, second: HSL | HSV | RGB): boolean => {
+export const equalColorObjects = (
+  first: HslColor | HsvColor | RgbColor,
+  second: HslColor | HsvColor | RgbColor
+): boolean => {
   if (first === second) return true;
 
   for (const prop in first) {

--- a/src/lib/utils/convert.ts
+++ b/src/lib/utils/convert.ts
@@ -1,8 +1,8 @@
-import type { HSL, HSV, RGB } from '../types';
+import type { HslColor, HsvColor, RgbColor } from '../types';
 
-export const hexToHsv = (hex: string): HSV => rgbToHsv(hexToRgb(hex));
+export const hexToHsv = (hex: string): HsvColor => rgbToHsv(hexToRgb(hex));
 
-export const hexToRgb = (hex: string): RGB => {
+export const hexToRgb = (hex: string): RgbColor => {
   if (hex[0] === '#') hex = hex.substr(1);
 
   if (hex.length < 6) {
@@ -20,7 +20,7 @@ export const hexToRgb = (hex: string): RGB => {
   };
 };
 
-export const hslStringToHsv = (hslString: string): HSV => {
+export const hslStringToHsv = (hslString: string): HsvColor => {
   const matcher = /hsl\((\d+(?:\.\d+)*),\s*(\d+(?:\.\d+)*)%?,\s*(\d+(?:\.\d+)*)%?\)/;
   const match = matcher.exec(hslString);
 
@@ -31,7 +31,7 @@ export const hslStringToHsv = (hslString: string): HSV => {
   });
 };
 
-export const hslToHsv = ({ h, s, l }: HSL): HSV => {
+export const hslToHsv = ({ h, s, l }: HslColor): HsvColor => {
   s *= (l < 50 ? l : 100 - l) / 100;
 
   return {
@@ -41,9 +41,9 @@ export const hslToHsv = ({ h, s, l }: HSL): HSV => {
   };
 };
 
-export const hsvToHex = (hsv: HSV): string => rgbToHex(hsvToRgb(hsv));
+export const hsvToHex = (hsv: HsvColor): string => rgbToHex(hsvToRgb(hsv));
 
-export const hsvToHsl = ({ h, s, v }: HSV): HSL => {
+export const hsvToHsl = ({ h, s, v }: HsvColor): HslColor => {
   const hh = ((200 - s) * v) / 100;
 
   return {
@@ -53,12 +53,12 @@ export const hsvToHsl = ({ h, s, v }: HSV): HSL => {
   };
 };
 
-export const hsvToHslString = (hsv: HSV): string => {
+export const hsvToHslString = (hsv: HsvColor): string => {
   const { h, s, l } = hsvToHsl(hsv);
   return `hsl(${h}, ${s}%, ${l}%)`;
 };
 
-export const hsvToRgb = ({ h, s, v }: HSV): RGB => {
+export const hsvToRgb = ({ h, s, v }: HsvColor): RgbColor => {
   h = (h / 360) * 6;
   s = s / 100;
   v = v / 100;
@@ -76,12 +76,12 @@ export const hsvToRgb = ({ h, s, v }: HSV): RGB => {
   };
 };
 
-export const hsvToRgbString = (hsv: HSV): string => {
+export const hsvToRgbString = (hsv: HsvColor): string => {
   const { r, g, b } = hsvToRgb(hsv);
   return `rgb(${r}, ${g}, ${b})`;
 };
 
-export const rgbStringToHsv = (rgbString: string): HSV => {
+export const rgbStringToHsv = (rgbString: string): HsvColor => {
   const matcher = /rgb\((\d+),\s*(\d+),\s*(\d+)\)/;
   const match = matcher.exec(rgbString);
 
@@ -97,9 +97,9 @@ const format = (number: number) => {
   return hex.length < 2 ? '0' + hex : hex;
 };
 
-export const rgbToHex = ({ r, g, b }: RGB): string => '#' + format(r) + format(g) + format(b);
+export const rgbToHex = ({ r, g, b }: RgbColor): string => '#' + format(r) + format(g) + format(b);
 
-export const rgbToHsv = ({ r, g, b }: RGB): HSV => {
+export const rgbToHsv = ({ r, g, b }: RgbColor): HsvColor => {
   const max = Math.max(r, g, b);
   const delta = max - Math.min(r, g, b);
 

--- a/src/rgb-color-picker.ts
+++ b/src/rgb-color-picker.ts
@@ -1,12 +1,12 @@
 import { RgbBase } from './lib/entrypoints/rgb.js';
-export type { RGB } from './lib/types';
+export type { RgbColor } from './lib/types';
 
 /**
  * A color picker custom element that uses RGB object format.
  *
- * @element color-picker-rgb
+ * @element rgb-color-picker
  *
- * @prop {RGB} color - Selected color in RGB object format.
+ * @prop {RgbColor} color - Selected color in RGB object format.
  *
  * @fires color-changed - Event fired when color property changes.
  *
@@ -15,12 +15,12 @@ export type { RGB } from './lib/types';
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  */
-export class ColorPickerRgb extends RgbBase {}
+export class RgbColorPicker extends RgbBase {}
 
-customElements.define('color-picker-rgb', ColorPickerRgb);
+customElements.define('rgb-color-picker', RgbColorPicker);
 
 declare global {
   interface HTMLElementTagNameMap {
-    'color-picker-rgb': ColorPickerRgb;
+    'rgb-color-picker': RgbColorPicker;
   }
 }

--- a/src/rgb-string-color-picker.ts
+++ b/src/rgb-string-color-picker.ts
@@ -3,7 +3,7 @@ import { RgbStringBase } from './lib/entrypoints/rgb-string.js';
 /**
  * A color picker custom element that uses RGB string format.
  *
- * @element color-picker-rgb-string
+ * @element rgb-string-color-picker
  *
  * @prop {string} color - Selected color in RGB string format.
  *
@@ -14,12 +14,12 @@ import { RgbStringBase } from './lib/entrypoints/rgb-string.js';
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  */
-export class ColorPickerRgbString extends RgbStringBase {}
+export class RgbStringColorPicker extends RgbStringBase {}
 
-customElements.define('color-picker-rgb-string', ColorPickerRgbString);
+customElements.define('rgb-string-color-picker', RgbStringColorPicker);
 
 declare global {
   interface HTMLElementTagNameMap {
-    'color-picker-rgb-string': ColorPickerRgbString;
+    'rgb-string-color-picker': RgbStringColorPicker;
   }
 }

--- a/src/test/color-picker.test.ts
+++ b/src/test/color-picker.test.ts
@@ -2,7 +2,7 @@ import { expect } from '@esm-bundle/chai';
 import sinon from 'sinon';
 import { fixture, html, nextFrame } from '@open-wc/testing-helpers';
 import { hexToHsv, hsvToRgbString } from '../lib/utils/convert';
-import type { ColorPickerHex } from '../color-picker-hex';
+import type { HexColorPicker } from '../hex-color-picker';
 import type { Hue } from '../lib/components/hue';
 import type { Saturation } from '../lib/components/saturation';
 
@@ -47,15 +47,15 @@ const getPointer = (node: Hue | Saturation) => {
   return node.shadowRoot!.querySelector('[part=pointer]') as HTMLElement;
 };
 
-describe('color-picker-hex', () => {
-  let picker: ColorPickerHex;
+describe('hex-color-picker', () => {
+  let picker: HexColorPicker;
 
   describe('lazy upgrade', () => {
     it('should work with color property set before upgrade', async () => {
-      picker = document.createElement('color-picker-hex');
+      picker = document.createElement('hex-color-picker');
       document.body.appendChild(picker);
       picker.color = '#123';
-      await import('../color-picker-hex');
+      await import('../hex-color-picker');
       expect(picker.color).to.equal('#123');
       document.body.removeChild(picker);
     });
@@ -63,7 +63,7 @@ describe('color-picker-hex', () => {
 
   describe('default', () => {
     beforeEach(async () => {
-      picker = await fixture(html`<color-picker-hex></color-picker-hex>`);
+      picker = await fixture(html`<hex-color-picker></hex-color-picker>`);
     });
 
     it('should set default color property value', () => {
@@ -77,7 +77,7 @@ describe('color-picker-hex', () => {
 
   describe('color property', () => {
     beforeEach(async () => {
-      picker = await fixture(html`<color-picker-hex .color="${'#ccc'}"></color-picker-hex>`);
+      picker = await fixture(html`<hex-color-picker .color="${'#ccc'}"></hex-color-picker>`);
     });
 
     it('should accept color set as a property', () => {
@@ -105,7 +105,7 @@ describe('color-picker-hex', () => {
 
   describe('color attribute', () => {
     beforeEach(async () => {
-      picker = document.createElement('color-picker-hex');
+      picker = document.createElement('hex-color-picker');
       picker.setAttribute('color', '#488');
       await nextFrame();
       document.body.appendChild(picker);
@@ -149,7 +149,7 @@ describe('color-picker-hex', () => {
     let saturation: Saturation;
 
     beforeEach(async () => {
-      picker = document.createElement('color-picker-hex');
+      picker = document.createElement('hex-color-picker');
       picker.color = '#488';
       await nextFrame();
       document.body.appendChild(picker);

--- a/src/test/hex-input.test.ts
+++ b/src/test/hex-input.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import { fixture, html } from '@open-wc/testing-helpers';
 import type { HexInput } from '../hex-input';
 
-describe('color-picker-hex', () => {
+describe('hex-input', () => {
   let input: HexInput;
   let target: HTMLInputElement;
 


### PR DESCRIPTION
Changing the tag names in order to make the type of the specific element in markup more easily discoverable.