### PR TITLE
refactor!: use Shadow DOM in hex-input

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ hex-color-picker::part(hue-pointer) {
 ```
 
 `<hex-input>` renders an unstyled `<input>` element inside a slot and exposes it for styling using
-`part`. You can also pass your own `<input>` element as a child, if you want to fully configure it.
+`part`. You can also pass your own `<input>` element as a child if you want to fully configure it.
 
 ## Base classes
 

--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ hex-color-picker::part(hue-pointer) {
 </script>
 ```
 
-`<hex-input>` does not use Shadow DOM and renders an `input` element without any custom styles. You
-can also provide a custom `input` element as a child if you want to configure it.
+`<hex-input>` renders an unstyled `<input>` element inside a slot and exposes it for styling using
+`part`. You can also pass your own `<input>` element as a child, if you want to fully configure it.
 
 ## Base classes
 

--- a/src/hex-input.ts
+++ b/src/hex-input.ts
@@ -9,6 +9,8 @@ import { HexInputBase } from './lib/entrypoints/hex-input.js';
  * @attr {string} color - Selected color in HEX format.
  *
  * @fires color-changed - Event fired when color is changed.
+ *
+ * @csspart input - A native input element.
  */
 export class HexInput extends HexInputBase {}
 

--- a/src/lib/entrypoints/hex-input.ts
+++ b/src/lib/entrypoints/hex-input.ts
@@ -1,4 +1,7 @@
 import { validHex } from '../utils/validate.js';
+import { createTemplate, createRoot } from '../utils/dom.js';
+
+const template = createTemplate('<slot><input part="input" spellcheck="false"></slot>');
 
 // Escapes all non-hexadecimal characters including "#"
 const escape = (hex: string) => hex.replace(/([^0-9A-F]+)/gi, '').substr(0, 6);
@@ -24,15 +27,23 @@ export class HexInputBase extends HTMLElement {
   }
 
   connectedCallback(): void {
-    let input = this.querySelector('input');
-    if (!input) {
-      input = document.createElement('input');
-      input.setAttribute('spellcheck', 'false');
-      this.appendChild(input);
-    }
-    input.addEventListener('input', this);
-    input.addEventListener('blur', this);
-    this._input = input;
+    const slot = createRoot(this, template).firstElementChild as HTMLSlotElement;
+    const setInput = () => {
+      let input = this.querySelector('input');
+      if (!input) {
+        // remove all child node if no input found
+        let c;
+        while ((c = this.firstChild)) {
+          this.removeChild(c);
+        }
+        input = slot.firstChild as HTMLInputElement;
+      }
+      input.addEventListener('input', this);
+      input.addEventListener('blur', this);
+      this._input = input;
+    };
+    slot.addEventListener('slotchange', setInput);
+    setInput();
 
     // A user may set a property on an _instance_ of an element,
     // before its prototype has been connected to this class.

--- a/src/test/hex-input.test.ts
+++ b/src/test/hex-input.test.ts
@@ -7,6 +7,11 @@ describe('hex-input', () => {
   let input: HexInput;
   let target: HTMLInputElement;
 
+  function getTarget(input: HexInput) {
+    const root = input.shadowRoot as ShadowRoot;
+    return root.querySelector('input') as HTMLInputElement;
+  }
+
   function inputChar(char: string) {
     target.value += char;
     target.dispatchEvent(new CustomEvent('input', { bubbles: true, composed: true }));
@@ -25,7 +30,7 @@ describe('hex-input', () => {
       element.color = '#123';
       await import('../hex-input');
       expect(element.color).to.equal('#123');
-      target = element.querySelector('input') as HTMLInputElement;
+      target = getTarget(element);
       expect(target.value).to.equal('123');
       document.body.removeChild(element);
     });
@@ -34,7 +39,7 @@ describe('hex-input', () => {
   describe('default', () => {
     beforeEach(async () => {
       input = await fixture(html`<hex-input></hex-input>`);
-      target = input.querySelector('input') as HTMLInputElement;
+      target = getTarget(input);
     });
 
     it('should set color property to empty string', () => {
@@ -43,6 +48,14 @@ describe('hex-input', () => {
 
     it('should set native input value to empty string', () => {
       expect(target.value).to.equal('');
+    });
+
+    it('should set part attribute on the native input', () => {
+      expect(target.getAttribute('part')).to.equal('input');
+    });
+
+    it('should set spellcheck to false on the native input', () => {
+      expect(target.getAttribute('spellcheck')).to.equal('false');
     });
   });
 
@@ -58,20 +71,20 @@ describe('hex-input', () => {
     it('should handle property set before adding to the DOM', () => {
       input.color = '#123';
       document.body.appendChild(input);
-      expect((input.querySelector('input') as HTMLInputElement).value).to.equal('123');
+      expect(getTarget(input).value).to.equal('123');
     });
 
     it('should handle attribute set before adding to the DOM', () => {
       input.setAttribute('color', '#123');
       document.body.appendChild(input);
-      expect((input.querySelector('input') as HTMLInputElement).value).to.equal('123');
+      expect(getTarget(input).value).to.equal('123');
     });
   });
 
   describe('color property', () => {
     beforeEach(async () => {
       input = await fixture(html`<hex-input .color="${'#ccc'}"></hex-input>`);
-      target = input.querySelector('input') as HTMLInputElement;
+      target = getTarget(input);
     });
 
     it('should accept color set as a property', () => {
@@ -90,7 +103,7 @@ describe('hex-input', () => {
   describe('color attribute', () => {
     beforeEach(async () => {
       input = await fixture(html`<hex-input color="#488"></hex-input>`);
-      target = input.querySelector('input') as HTMLInputElement;
+      target = getTarget(input);
     });
 
     it('should set color based on the attribute value', () => {
@@ -115,7 +128,7 @@ describe('hex-input', () => {
   describe('empty value', () => {
     beforeEach(async () => {
       input = await fixture(html`<hex-input color="#488"></hex-input>`);
-      target = input.querySelector('input') as HTMLInputElement;
+      target = getTarget(input);
     });
 
     it('should clean native input when color is set to empty string', () => {
@@ -152,10 +165,20 @@ describe('hex-input', () => {
     });
   });
 
+  describe('invalid content', () => {
+    beforeEach(async () => {
+      input = await fixture(html`<hex-input color="#488"><span></span></hex-input>`);
+    });
+
+    it('should remove invalid slotted content', () => {
+      expect(input.querySelector('span')).to.be.not.ok;
+    });
+  });
+
   describe('events', () => {
     beforeEach(async () => {
       input = await fixture(html`<hex-input color="#488"></hex-input>`);
-      target = input.querySelector('input') as HTMLInputElement;
+      target = getTarget(input);
     });
 
     it('should dispatch color-changed event on valid hex input', () => {


### PR DESCRIPTION
This is a breaking change which prevents the `hex-input` from attaching an `input` to its own light DOM.
Instead the `<slot>` with a fallback content is used, with a `slotchange` event listener to handle custom input.