### PR TITLE
fix: add hex-color-picker export

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "exports": {
     ".": "./hex-color-picker.js",
     "./hex-input.js": "./hex-input.js",
+    "./hex-color-picker.js": "./hex-color-picker.js",
     "./hsl-color-picker.js": "./hsl-color-picker.js",
     "./hsl-string-color-picker.js": "./hsl-string-color-picker.js",
     "./hsla-color-picker.js": "./hsla-color-picker.js",


### PR DESCRIPTION
when respecting the exports field all entry points need to be in it 😅

I wanted to use the `hex-color-picker.js` but it was missing so I added it