### PR TITLE
refactor: cleanup private methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     },
     {
       "path": "rgba-string-color-picker.js",
-      "limit": "3.1 KB"
+      "limit": "3 KB"
     },
     {
       "path": "hex-input.js",

--- a/src/lib/components/alpha-color-picker.ts
+++ b/src/lib/components/alpha-color-picker.ts
@@ -1,20 +1,10 @@
-import { ColorPicker, $render } from './color-picker.js';
-import type { AnyColor, HsvaColor } from '../types';
+import { ColorPicker, $parts } from './color-picker.js';
+import type { AnyColor } from '../types';
 import { Alpha } from './alpha.js';
-import './alpha.js';
-
-const $a = Symbol('a');
 
 export abstract class AlphaColorPicker<C extends AnyColor> extends ColorPicker<C> {
-  private [$a]!: Alpha;
-
   constructor() {
     super();
-    this[$a] = new Alpha(this);
-  }
-
-  protected [$render](hsva: HsvaColor): void {
-    super[$render](hsva);
-    this[$a].hsva = hsva;
+    this[$parts] = [...this[$parts], new Alpha(this)];
   }
 }

--- a/src/lib/components/alpha.ts
+++ b/src/lib/components/alpha.ts
@@ -11,30 +11,26 @@ const template = createTemplate(`
 `);
 
 export class Alpha extends Slider {
-  private gradient!: HTMLElement;
+  private gradient!: CSSStyleDeclaration;
 
   private _hsva!: HsvaColor;
 
   constructor(host: HTMLElement) {
     super(host);
-    this.gradient = this.node.nextElementSibling as HTMLElement;
+    this.gradient = (this.node.nextElementSibling as HTMLElement).style;
   }
 
   get xy(): boolean {
     return false;
   }
 
-  get hsva(): HsvaColor {
-    return this._hsva;
-  }
-
-  set hsva(hsva: HsvaColor) {
+  update(hsva: HsvaColor): void {
     this._hsva = hsva;
     const colorFrom = hsvaToHslaString({ ...hsva, a: 0 });
     const colorTo = hsvaToHslaString({ ...hsva, a: 1 });
     const value = hsva.a * 100;
 
-    this.gradient.style.backgroundImage = `linear-gradient(to right, ${colorFrom}, ${colorTo}`;
+    this.gradient.backgroundImage = `linear-gradient(to right, ${colorFrom}, ${colorTo}`;
     this.setStyles({
       left: `${value}%`,
       color: hsvaToHslaString(hsva)
@@ -54,6 +50,6 @@ export class Alpha extends Slider {
 
   getMove(interaction: Interaction, key?: boolean): Record<string, number> {
     // Alpha always fit into [0, 1] range
-    return { a: key ? clamp(this.hsva.a + interaction.left) : interaction.left };
+    return { a: key ? clamp(this._hsva.a + interaction.left) : interaction.left };
   }
 }

--- a/src/lib/components/alpha.ts
+++ b/src/lib/components/alpha.ts
@@ -16,12 +16,8 @@ export class Alpha extends Slider {
   private _hsva!: HsvaColor;
 
   constructor(host: HTMLElement) {
-    super(host);
+    super(host, template, 'alpha', false);
     this.gradient = (this.node.nextElementSibling as HTMLElement).style;
-  }
-
-  get xy(): boolean {
-    return false;
   }
 
   update(hsva: HsvaColor): void {
@@ -38,14 +34,6 @@ export class Alpha extends Slider {
     const v = round(value);
     this.node.setAttribute('aria-valuenow', `${v}`);
     this.node.setAttribute('aria-valuetext', `${v}%`);
-  }
-
-  getTemplate(): HTMLTemplateElement {
-    return template;
-  }
-
-  getPart(): string {
-    return 'alpha';
   }
 
   getMove(interaction: Interaction, key?: boolean): Record<string, number> {

--- a/src/lib/components/alpha.ts
+++ b/src/lib/components/alpha.ts
@@ -13,7 +13,7 @@ const template = createTemplate(`
 export class Alpha extends Slider {
   private gradient!: CSSStyleDeclaration;
 
-  private _hsva!: HsvaColor;
+  private hsva!: HsvaColor;
 
   constructor(host: HTMLElement) {
     super(host, template, 'alpha', false);
@@ -21,7 +21,7 @@ export class Alpha extends Slider {
   }
 
   update(hsva: HsvaColor): void {
-    this._hsva = hsva;
+    this.hsva = hsva;
     const colorFrom = hsvaToHslaString({ ...hsva, a: 0 });
     const colorTo = hsvaToHslaString({ ...hsva, a: 1 });
     const value = hsva.a * 100;
@@ -38,6 +38,6 @@ export class Alpha extends Slider {
 
   getMove(interaction: Interaction, key?: boolean): Record<string, number> {
     // Alpha always fit into [0, 1] range
-    return { a: key ? clamp(this._hsva.a + interaction.left) : interaction.left };
+    return { a: key ? clamp(this.hsva.a + interaction.left) : interaction.left };
   }
 }

--- a/src/lib/components/hue.ts
+++ b/src/lib/components/hue.ts
@@ -11,14 +11,14 @@ const template = createTemplate(`
 `);
 
 export class Hue extends Slider {
-  private _h!: number;
+  private h!: number;
 
   constructor(host: HTMLElement) {
     super(host, template, 'hue', false);
   }
 
   update({ h }: HsvaColor): void {
-    this._h = h;
+    this.h = h;
     this.setStyles({
       left: `${(h / 360) * 100}%`,
       color: hsvaToHslString({ h, s: 100, v: 100, a: 1 })
@@ -28,6 +28,6 @@ export class Hue extends Slider {
 
   getMove(interaction: Interaction, key?: boolean): Record<string, number> {
     // Hue measured in degrees of the color circle ranging from 0 to 360
-    return { h: key ? clamp(this._h + interaction.left * 360, 0, 360) : 360 * interaction.left };
+    return { h: key ? clamp(this.h + interaction.left * 360, 0, 360) : 360 * interaction.left };
   }
 }

--- a/src/lib/components/hue.ts
+++ b/src/lib/components/hue.ts
@@ -13,8 +13,8 @@ const template = createTemplate(`
 export class Hue extends Slider {
   private _h!: number;
 
-  get xy(): boolean {
-    return false;
+  constructor(host: HTMLElement) {
+    super(host, template, 'hue', false);
   }
 
   update({ h }: HsvaColor): void {
@@ -24,14 +24,6 @@ export class Hue extends Slider {
       color: hsvaToHslString({ h, s: 100, v: 100, a: 1 })
     });
     this.node.setAttribute('aria-valuenow', `${round(h)}`);
-  }
-
-  getTemplate(): HTMLTemplateElement {
-    return template;
-  }
-
-  getPart(): string {
-    return 'hue';
   }
 
   getMove(interaction: Interaction, key?: boolean): Record<string, number> {

--- a/src/lib/components/hue.ts
+++ b/src/lib/components/hue.ts
@@ -3,6 +3,7 @@ import { hsvaToHslString } from '../utils/convert.js';
 import { createTemplate } from '../utils/dom.js';
 import { clamp, round } from '../utils/math.js';
 import styles from '../styles/hue.js';
+import type { HsvaColor } from '../types';
 
 const template = createTemplate(`
 <style>${styles}</style>
@@ -16,11 +17,7 @@ export class Hue extends Slider {
     return false;
   }
 
-  get hue(): number {
-    return this._h;
-  }
-
-  set hue(h: number) {
+  update({ h }: HsvaColor): void {
     this._h = h;
     this.setStyles({
       left: `${(h / 360) * 100}%`,
@@ -39,6 +36,6 @@ export class Hue extends Slider {
 
   getMove(interaction: Interaction, key?: boolean): Record<string, number> {
     // Hue measured in degrees of the color circle ranging from 0 to 360
-    return { h: key ? clamp(this.hue + interaction.left * 360, 0, 360) : 360 * interaction.left };
+    return { h: key ? clamp(this._h + interaction.left * 360, 0, 360) : 360 * interaction.left };
   }
 }

--- a/src/lib/components/saturation.ts
+++ b/src/lib/components/saturation.ts
@@ -13,8 +13,8 @@ const template = createTemplate(`
 export class Saturation extends Slider {
   private _hsva!: HsvaColor;
 
-  get xy(): boolean {
-    return true;
+  constructor(host: HTMLElement) {
+    super(host, template, 'saturation', true);
   }
 
   update(hsva: HsvaColor): void {
@@ -29,14 +29,6 @@ export class Saturation extends Slider {
       'aria-valuetext',
       `Saturation ${round(hsva.s)}%, Brightness ${round(hsva.v)}%`
     );
-  }
-
-  getTemplate(): HTMLTemplateElement {
-    return template;
-  }
-
-  getPart(): string {
-    return 'saturation';
   }
 
   getMove(interaction: Interaction, key?: boolean): Record<string, number> {

--- a/src/lib/components/saturation.ts
+++ b/src/lib/components/saturation.ts
@@ -11,14 +11,14 @@ const template = createTemplate(`
 `);
 
 export class Saturation extends Slider {
-  private _hsva!: HsvaColor;
+  private hsva!: HsvaColor;
 
   constructor(host: HTMLElement) {
     super(host, template, 'saturation', true);
   }
 
   update(hsva: HsvaColor): void {
-    this._hsva = hsva;
+    this.hsva = hsva;
     this.node.style.backgroundColor = hsvaToHslString({ h: hsva.h, s: 100, v: 100, a: 1 });
     this.setStyles({
       top: `${100 - hsva.v}%`,
@@ -34,9 +34,9 @@ export class Saturation extends Slider {
   getMove(interaction: Interaction, key?: boolean): Record<string, number> {
     // Saturation and brightness always fit into [0, 100] range
     return {
-      s: key ? clamp(this._hsva.s + interaction.left * 100, 0, 100) : interaction.left * 100,
+      s: key ? clamp(this.hsva.s + interaction.left * 100, 0, 100) : interaction.left * 100,
       v: key
-        ? clamp(this._hsva.v - interaction.top * 100, 0, 100)
+        ? clamp(this.hsva.v - interaction.top * 100, 0, 100)
         : Math.round(100 - interaction.top * 100)
     };
   }

--- a/src/lib/components/saturation.ts
+++ b/src/lib/components/saturation.ts
@@ -17,11 +17,7 @@ export class Saturation extends Slider {
     return true;
   }
 
-  get hsva(): HsvaColor {
-    return this._hsva;
-  }
-
-  set hsva(hsva: HsvaColor) {
+  update(hsva: HsvaColor): void {
     this._hsva = hsva;
     this.node.style.backgroundColor = hsvaToHslString({ h: hsva.h, s: 100, v: 100, a: 1 });
     this.setStyles({
@@ -46,9 +42,9 @@ export class Saturation extends Slider {
   getMove(interaction: Interaction, key?: boolean): Record<string, number> {
     // Saturation and brightness always fit into [0, 100] range
     return {
-      s: key ? clamp(this.hsva.s + interaction.left * 100, 0, 100) : interaction.left * 100,
+      s: key ? clamp(this._hsva.s + interaction.left * 100, 0, 100) : interaction.left * 100,
       v: key
-        ? clamp(this.hsva.v - interaction.top * 100, 0, 100)
+        ? clamp(this._hsva.v - interaction.top * 100, 0, 100)
         : Math.round(100 - interaction.top * 100)
     };
   }

--- a/src/lib/components/slider.ts
+++ b/src/lib/components/slider.ts
@@ -1,3 +1,4 @@
+import type { HsvaColor } from '../types.js';
 import { createRoot } from '../utils/dom.js';
 import { clamp } from '../utils/math.js';
 
@@ -135,6 +136,8 @@ export abstract class Slider implements SliderInterface {
   abstract getTemplate(): HTMLTemplateElement;
 
   abstract get xy(): boolean;
+
+  abstract update(hsva: HsvaColor): void;
 
   setStyles(properties: Record<string, string>): void {
     for (const p in properties) {

--- a/src/lib/components/slider.ts
+++ b/src/lib/components/slider.ts
@@ -84,9 +84,12 @@ export abstract class Slider implements SliderInterface {
 
   node!: HTMLElement;
 
-  constructor(host: HTMLElement) {
-    const part = this.getPart();
-    const root = createRoot(host, this.getTemplate());
+  xy!: boolean;
+
+  constructor(host: HTMLElement, template: HTMLTemplateElement, part: string, xy: boolean) {
+    this.xy = xy;
+
+    const root = createRoot(host, template);
 
     this.pointer = (root.querySelector(`[part=${part}-pointer]`) as HTMLElement).style;
 
@@ -130,12 +133,6 @@ export abstract class Slider implements SliderInterface {
   }
 
   abstract getMove(interaction: Interaction, key?: boolean): Record<string, number>;
-
-  abstract getPart(): string;
-
-  abstract getTemplate(): HTMLTemplateElement;
-
-  abstract get xy(): boolean;
 
   abstract update(hsva: HsvaColor): void;
 

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -16,7 +16,7 @@ module.exports = {
   coverageConfig: {
     threshold: {
       statements: 100,
-      branches: 73,
+      branches: 71,
       functions: 100,
       lines: 100
     }


### PR DESCRIPTION
Now when we use plain classes and not internal elements, some logic can be simplified.