### PR TITLE
refactor: use pseudo-element for gradient

### DIFF
--- a/src/hsla-color-picker.ts
+++ b/src/hsla-color-picker.ts
@@ -16,7 +16,6 @@ export type { HslaColor } from './lib/types';
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  * @csspart alpha-pointer - An alpha pointer element.
- * @csspart alpha-gradient - An alpha gradient element.
  */
 export class HslaColorPicker extends HslaBase {}
 

--- a/src/hsla-string-color-picker.ts
+++ b/src/hsla-string-color-picker.ts
@@ -16,7 +16,6 @@ import { HslaStringBase } from './lib/entrypoints/hsla-string.js';
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  * @csspart alpha-pointer - An alpha pointer element.
- * @csspart alpha-gradient - An alpha gradient element.
  */
 export class HslaStringColorPicker extends HslaStringBase {}
 

--- a/src/hsva-color-picker.ts
+++ b/src/hsva-color-picker.ts
@@ -14,7 +14,6 @@ export type { HsvaColor } from './lib/types';
  * @csspart saturation - A saturation selector container
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
- * @csspart alpha-gradient - An alpha gradient element.
  */
 export class HsvaColorPicker extends HsvaBase {}
 

--- a/src/hsva-string-color-picker.ts
+++ b/src/hsva-string-color-picker.ts
@@ -16,7 +16,6 @@ import { HsvaStringBase } from './lib/entrypoints/hsva-string.js';
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  * @csspart alpha-pointer - An alpha pointer element.
- * @csspart alpha-gradient - An alpha gradient element.
  */
 export class HsvaStringColorPicker extends HsvaStringBase {}
 

--- a/src/lib/components/alpha.ts
+++ b/src/lib/components/alpha.ts
@@ -7,13 +7,7 @@ export class Alpha extends Slider {
   private hsva!: HsvaColor;
 
   constructor(root: ShadowRoot) {
-    super(
-      root,
-      '<div role="slider" part="alpha" aria-label="Alpha" aria-valuemin="0" aria-valuemax="1"><div part="alpha-pointer"></div></div><span part="gradient"></span>',
-      'alpha',
-      false
-    );
-    this.nodes.push(this.el.nextElementSibling as HTMLElement);
+    super(root, 'alpha', 'aria-label="Alpha" aria-valuemin="0" aria-valuemax="1"', false);
   }
 
   update(hsva: HsvaColor): void {
@@ -28,7 +22,7 @@ export class Alpha extends Slider {
         color: hsvaToHslaString(hsva)
       },
       {
-        backgroundImage: `linear-gradient(to right, ${colorFrom}, ${colorTo}`
+        '--gradient': `linear-gradient(90deg, ${colorFrom}, ${colorTo}`
       }
     ]);
 

--- a/src/lib/components/hue.ts
+++ b/src/lib/components/hue.ts
@@ -7,12 +7,7 @@ export class Hue extends Slider {
   private h!: number;
 
   constructor(root: ShadowRoot) {
-    super(
-      root,
-      '<div role="slider" part="hue" aria-label="Hue" aria-valuemin="0" aria-valuemax="360"><div part="hue-pointer"></div></div>',
-      'hue',
-      false
-    );
+    super(root, 'hue', 'aria-label="Hue" aria-valuemin="0" aria-valuemax="360"', false);
   }
 
   update({ h }: HsvaColor): void {

--- a/src/lib/components/saturation.ts
+++ b/src/lib/components/saturation.ts
@@ -7,13 +7,7 @@ export class Saturation extends Slider {
   private hsva!: HsvaColor;
 
   constructor(root: ShadowRoot) {
-    super(
-      root,
-      '<div role="slider" part="saturation" aria-label="Color"><div part="saturation-pointer"></div></div>',
-      'saturation',
-      true
-    );
-    this.nodes.push(this.el);
+    super(root, 'saturation', 'aria-label="Color"', true);
   }
 
   update(hsva: HsvaColor): void {
@@ -25,7 +19,7 @@ export class Saturation extends Slider {
         color: hsvaToHslString(hsva)
       },
       {
-        backgroundColor: hsvaToHslString({ h: hsva.h, s: 100, v: 100, a: 1 })
+        'background-color': hsvaToHslString({ h: hsva.h, s: 100, v: 100, a: 1 })
       }
     ]);
     this.el.setAttribute(

--- a/src/lib/components/slider.ts
+++ b/src/lib/components/slider.ts
@@ -82,18 +82,20 @@ export abstract class Slider {
 
   xy!: boolean;
 
-  constructor(root: ShadowRoot, template: string, part: string, xy: boolean) {
-    root.appendChild(createTemplate(template).content.cloneNode(true));
+  constructor(root: ShadowRoot, part: string, aria: string, xy: boolean) {
+    const tpl = createTemplate(
+      `<div role="slider" tabindex="0" part="${part}" ${aria}><div part="${part}-pointer"></div></div>`
+    );
+    root.appendChild(tpl.content.cloneNode(true));
 
     const el = root.querySelector(`[part=${part}]`) as HTMLElement;
     el.addEventListener('mousedown', this);
     el.addEventListener('touchstart', this);
     el.addEventListener('keydown', this);
-    el.setAttribute('tabindex', '0');
     this.el = el;
 
     this.xy = xy;
-    this.nodes = [root.querySelector(`[part=${part}-pointer]`) as HTMLElement];
+    this.nodes = [el.firstElementChild as HTMLElement, el];
   }
 
   set dragging(state: boolean) {
@@ -133,7 +135,9 @@ export abstract class Slider {
 
   style(styles: Array<Record<string, string>>): void {
     styles.forEach((style, i) => {
-      Object.assign(this.nodes[i].style, style);
+      for (const p in style) {
+        this.nodes[i].style.setProperty(p, style[p]);
+      }
     });
   }
 }

--- a/src/lib/styles/alpha.scss
+++ b/src/lib/styles/alpha.scss
@@ -8,11 +8,11 @@
   display: block;
   content: "";
   position: absolute;
+  top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  height: 24px;
-  border-radius: 0 0 8px 8px;
+  border-radius: inherit;
   background-image: var(--gradient);
   /* Improve rendering on light backgrounds */
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);

--- a/src/lib/styles/alpha.scss
+++ b/src/lib/styles/alpha.scss
@@ -4,14 +4,16 @@
   background-color: #fff;
 }
 
-[part=gradient] {
+[part=alpha]::after {
+  display: block;
+  content: "";
   position: absolute;
   left: 0;
   right: 0;
   bottom: 0;
   height: 24px;
-  pointer-events: none;
   border-radius: 0 0 8px 8px;
+  background-image: var(--gradient);
   /* Improve rendering on light backgrounds */
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05);
 }

--- a/src/lib/styles/color-picker.scss
+++ b/src/lib/styles/color-picker.scss
@@ -26,7 +26,7 @@
 }
 
 /* Round bottom corners of the last element: `Hue` or `Alpha` */
-[role=slider]:last-of-type {
+[role=slider]:last-child {
   border-radius: 0 0 8px 8px;
 }
 

--- a/src/rgba-color-picker.ts
+++ b/src/rgba-color-picker.ts
@@ -16,7 +16,6 @@ export type { RgbaColor } from './lib/types';
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  * @csspart alpha-pointer - An alpha pointer element.
- * @csspart alpha-gradient - An alpha gradient element.
  */
 export class RgbaColorPicker extends RgbaBase {}
 

--- a/src/rgba-string-color-picker.ts
+++ b/src/rgba-string-color-picker.ts
@@ -16,7 +16,6 @@ import { RgbaStringBase } from './lib/entrypoints/rgba-string.js';
  * @csspart hue-pointer - A hue pointer element.
  * @csspart saturation-pointer - A saturation pointer element.
  * @csspart alpha-pointer - An alpha pointer element.
- * @csspart alpha-gradient - An alpha gradient element.
  */
 export class RgbaStringColorPicker extends RgbaStringBase {}
 


### PR DESCRIPTION
Removed extra gradient part, which allowed to simplify slider templates even more.