### PR TITLE
feat: add color-changed event typings

### DIFF
--- a/src/lib/entrypoints/hex-input.ts
+++ b/src/lib/entrypoints/hex-input.ts
@@ -1,3 +1,4 @@
+import type { ColorPickerEventListener, ColorPickerEventMap } from '../types';
 import { validHex } from '../utils/validate.js';
 import { createTemplate } from '../utils/dom.js';
 
@@ -10,6 +11,20 @@ const $color = Symbol('color');
 const $saved = Symbol('saved');
 const $input = Symbol('saved');
 const $update = Symbol('update');
+
+export interface HexInputBase {
+  addEventListener<T extends keyof ColorPickerEventMap<string>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<string>[T]>,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener<T extends keyof ColorPickerEventMap<string>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<string>[T]>,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
 
 export class HexInputBase extends HTMLElement {
   static get observedAttributes(): string[] {

--- a/src/lib/entrypoints/hex.ts
+++ b/src/lib/entrypoints/hex.ts
@@ -1,4 +1,4 @@
-import type { ColorModel } from '../types';
+import type { ColorModel, ColorPickerEventListener, ColorPickerEventMap } from '../types';
 import { ColorPicker } from '../components/color-picker.js';
 import { hexToHsva, hsvaToHex } from '../utils/convert.js';
 import { equalHex } from '../utils/compare.js';
@@ -10,6 +10,20 @@ const colorModel: ColorModel<string> = {
   equal: equalHex,
   fromAttr: (color) => color
 };
+
+export interface HexBase {
+  addEventListener<T extends keyof ColorPickerEventMap<string>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<string>[T]>,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener<T extends keyof ColorPickerEventMap<string>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<string>[T]>,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
 
 export class HexBase extends ColorPicker<string> {
   protected get colorModel(): ColorModel<string> {

--- a/src/lib/entrypoints/hsl-string.ts
+++ b/src/lib/entrypoints/hsl-string.ts
@@ -1,4 +1,4 @@
-import type { ColorModel } from '../types';
+import type { ColorModel, ColorPickerEventListener, ColorPickerEventMap } from '../types';
 import { ColorPicker } from '../components/color-picker.js';
 import { hslStringToHsva, hsvaToHslString } from '../utils/convert.js';
 import { equalColorString } from '../utils/compare.js';
@@ -10,6 +10,20 @@ const colorModel: ColorModel<string> = {
   equal: equalColorString,
   fromAttr: (color) => color
 };
+
+export interface HslStringBase {
+  addEventListener<T extends keyof ColorPickerEventMap<string>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<string>[T]>,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener<T extends keyof ColorPickerEventMap<string>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<string>[T]>,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
 
 export class HslStringBase extends ColorPicker<string> {
   protected get colorModel(): ColorModel<string> {

--- a/src/lib/entrypoints/hsl.ts
+++ b/src/lib/entrypoints/hsl.ts
@@ -1,4 +1,4 @@
-import type { ColorModel, HslColor } from '../types';
+import type { ColorModel, ColorPickerEventListener, ColorPickerEventMap, HslColor } from '../types';
 import { ColorPicker } from '../components/color-picker.js';
 import { hslaToHsva, hsvaToHsla, hslaToHsl } from '../utils/convert.js';
 import { equalColorObjects } from '../utils/compare.js';
@@ -10,6 +10,20 @@ const colorModel: ColorModel<HslColor> = {
   equal: equalColorObjects,
   fromAttr: (color) => JSON.parse(color)
 };
+
+export interface HslBase {
+  addEventListener<T extends keyof ColorPickerEventMap<HslColor>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<HslColor>[T]>,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener<T extends keyof ColorPickerEventMap<HslColor>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<HslColor>[T]>,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
 
 export class HslBase extends ColorPicker<HslColor> {
   protected get colorModel(): ColorModel<HslColor> {

--- a/src/lib/entrypoints/hsla-string.ts
+++ b/src/lib/entrypoints/hsla-string.ts
@@ -1,4 +1,4 @@
-import type { ColorModel } from '../types';
+import type { ColorModel, ColorPickerEventListener, ColorPickerEventMap } from '../types';
 import { AlphaColorPicker } from '../components/alpha-color-picker.js';
 import { hslaStringToHsva, hsvaToHslaString } from '../utils/convert.js';
 import { equalColorString } from '../utils/compare.js';
@@ -10,6 +10,20 @@ const colorModel: ColorModel<string> = {
   equal: equalColorString,
   fromAttr: (color) => color
 };
+
+export interface HslaStringBase {
+  addEventListener<T extends keyof ColorPickerEventMap<string>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<string>[T]>,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener<T extends keyof ColorPickerEventMap<string>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<string>[T]>,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
 
 export class HslaStringBase extends AlphaColorPicker<string> {
   protected get colorModel(): ColorModel<string> {

--- a/src/lib/entrypoints/hsla.ts
+++ b/src/lib/entrypoints/hsla.ts
@@ -1,4 +1,9 @@
-import type { ColorModel, HslaColor } from '../types';
+import type {
+  ColorModel,
+  ColorPickerEventListener,
+  ColorPickerEventMap,
+  HslaColor
+} from '../types';
 import { AlphaColorPicker } from '../components/alpha-color-picker.js';
 import { hslaToHsva, hsvaToHsla } from '../utils/convert.js';
 import { equalColorObjects } from '../utils/compare.js';
@@ -10,6 +15,20 @@ const colorModel: ColorModel<HslaColor> = {
   equal: equalColorObjects,
   fromAttr: (color) => JSON.parse(color)
 };
+
+export interface HslaBase {
+  addEventListener<T extends keyof ColorPickerEventMap<HslaColor>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<HslaColor>[T]>,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener<T extends keyof ColorPickerEventMap<HslaColor>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<HslaColor>[T]>,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
 
 export class HslaBase extends AlphaColorPicker<HslaColor> {
   protected get colorModel(): ColorModel<HslaColor> {

--- a/src/lib/entrypoints/hsv-string.ts
+++ b/src/lib/entrypoints/hsv-string.ts
@@ -1,4 +1,4 @@
-import type { ColorModel } from '../types';
+import type { ColorModel, ColorPickerEventListener, ColorPickerEventMap } from '../types';
 import { ColorPicker } from '../components/color-picker.js';
 import { hsvStringToHsva, hsvaToHsvString } from '../utils/convert.js';
 import { equalColorString } from '../utils/compare.js';
@@ -10,6 +10,20 @@ const colorModel: ColorModel<string> = {
   equal: equalColorString,
   fromAttr: (color) => color
 };
+
+export interface HsvStringBase {
+  addEventListener<T extends keyof ColorPickerEventMap<string>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<string>[T]>,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener<T extends keyof ColorPickerEventMap<string>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<string>[T]>,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
 
 export class HsvStringBase extends ColorPicker<string> {
   protected get colorModel(): ColorModel<string> {

--- a/src/lib/entrypoints/hsv.ts
+++ b/src/lib/entrypoints/hsv.ts
@@ -1,4 +1,4 @@
-import type { ColorModel, HsvColor } from '../types';
+import type { ColorModel, ColorPickerEventListener, ColorPickerEventMap, HsvColor } from '../types';
 import { ColorPicker } from '../components/color-picker.js';
 import { hsvaToHsv } from '../utils/convert.js';
 import { equalColorObjects } from '../utils/compare.js';
@@ -10,6 +10,20 @@ const colorModel: ColorModel<HsvColor> = {
   equal: equalColorObjects,
   fromAttr: (color) => JSON.parse(color)
 };
+
+export interface HsvBase {
+  addEventListener<T extends keyof ColorPickerEventMap<HsvColor>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<HsvColor>[T]>,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener<T extends keyof ColorPickerEventMap<HsvColor>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<HsvColor>[T]>,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
 
 export class HsvBase extends ColorPicker<HsvColor> {
   protected get colorModel(): ColorModel<HsvColor> {

--- a/src/lib/entrypoints/hsva-string.ts
+++ b/src/lib/entrypoints/hsva-string.ts
@@ -1,4 +1,4 @@
-import type { ColorModel } from '../types';
+import type { ColorModel, ColorPickerEventListener, ColorPickerEventMap } from '../types';
 import { AlphaColorPicker } from '../components/alpha-color-picker.js';
 import { hsvaStringToHsva, hsvaToHsvaString } from '../utils/convert.js';
 import { equalColorString } from '../utils/compare.js';
@@ -10,6 +10,20 @@ const colorModel: ColorModel<string> = {
   equal: equalColorString,
   fromAttr: (color) => color
 };
+
+export interface HsvaStringBase {
+  addEventListener<T extends keyof ColorPickerEventMap<string>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<string>[T]>,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener<T extends keyof ColorPickerEventMap<string>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<string>[T]>,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
 
 export class HsvaStringBase extends AlphaColorPicker<string> {
   protected get colorModel(): ColorModel<string> {

--- a/src/lib/entrypoints/hsva.ts
+++ b/src/lib/entrypoints/hsva.ts
@@ -1,4 +1,9 @@
-import type { ColorModel, HsvaColor } from '../types';
+import type {
+  ColorModel,
+  ColorPickerEventListener,
+  ColorPickerEventMap,
+  HsvaColor
+} from '../types';
 import { AlphaColorPicker } from '../components/alpha-color-picker.js';
 import { equalColorObjects } from '../utils/compare.js';
 import { roundHsva } from '../utils/convert.js';
@@ -10,6 +15,20 @@ const colorModel: ColorModel<HsvaColor> = {
   equal: equalColorObjects,
   fromAttr: (color) => JSON.parse(color)
 };
+
+export interface HsvaBase {
+  addEventListener<T extends keyof ColorPickerEventMap<HsvaColor>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<HsvaColor>[T]>,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener<T extends keyof ColorPickerEventMap<HsvaColor>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<HsvaColor>[T]>,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
 
 export class HsvaBase extends AlphaColorPicker<HsvaColor> {
   protected get colorModel(): ColorModel<HsvaColor> {

--- a/src/lib/entrypoints/rgb-string.ts
+++ b/src/lib/entrypoints/rgb-string.ts
@@ -1,4 +1,4 @@
-import type { ColorModel } from '../types';
+import type { ColorModel, ColorPickerEventListener, ColorPickerEventMap } from '../types';
 import { ColorPicker } from '../components/color-picker.js';
 import { rgbStringToHsva, hsvaToRgbString } from '../utils/convert.js';
 import { equalColorString } from '../utils/compare.js';
@@ -10,6 +10,20 @@ const colorModel: ColorModel<string> = {
   equal: equalColorString,
   fromAttr: (color) => color
 };
+
+export interface RgbStringBase {
+  addEventListener<T extends keyof ColorPickerEventMap<string>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<string>[T]>,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener<T extends keyof ColorPickerEventMap<string>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<string>[T]>,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
 
 export class RgbStringBase extends ColorPicker<string> {
   protected get colorModel(): ColorModel<string> {

--- a/src/lib/entrypoints/rgb.ts
+++ b/src/lib/entrypoints/rgb.ts
@@ -1,4 +1,4 @@
-import type { ColorModel, RgbColor } from '../types';
+import type { ColorModel, ColorPickerEventListener, ColorPickerEventMap, RgbColor } from '../types';
 import { ColorPicker } from '../components/color-picker.js';
 import { rgbaToHsva, hsvaToRgba, rgbaToRgb } from '../utils/convert.js';
 import { equalColorObjects } from '../utils/compare.js';
@@ -10,6 +10,20 @@ const colorModel: ColorModel<RgbColor> = {
   equal: equalColorObjects,
   fromAttr: (color) => JSON.parse(color)
 };
+
+export interface RgbBase {
+  addEventListener<T extends keyof ColorPickerEventMap<RgbColor>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<RgbColor>[T]>,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener<T extends keyof ColorPickerEventMap<RgbColor>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<RgbColor>[T]>,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
 
 export class RgbBase extends ColorPicker<RgbColor> {
   protected get colorModel(): ColorModel<RgbColor> {

--- a/src/lib/entrypoints/rgba-string.ts
+++ b/src/lib/entrypoints/rgba-string.ts
@@ -1,4 +1,4 @@
-import type { ColorModel } from '../types';
+import type { ColorModel, ColorPickerEventListener, ColorPickerEventMap } from '../types';
 import { AlphaColorPicker } from '../components/alpha-color-picker.js';
 import { rgbaStringToHsva, hsvaToRgbaString } from '../utils/convert.js';
 import { equalColorString } from '../utils/compare.js';
@@ -10,6 +10,20 @@ const colorModel: ColorModel<string> = {
   equal: equalColorString,
   fromAttr: (color) => color
 };
+
+export interface RgbaStringBase {
+  addEventListener<T extends keyof ColorPickerEventMap<string>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<string>[T]>,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener<T extends keyof ColorPickerEventMap<string>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<string>[T]>,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
 
 export class RgbaStringBase extends AlphaColorPicker<string> {
   protected get colorModel(): ColorModel<string> {

--- a/src/lib/entrypoints/rgba.ts
+++ b/src/lib/entrypoints/rgba.ts
@@ -1,4 +1,9 @@
-import type { ColorModel, RgbaColor } from '../types';
+import type {
+  ColorModel,
+  ColorPickerEventListener,
+  ColorPickerEventMap,
+  RgbaColor
+} from '../types';
 import { AlphaColorPicker } from '../components/alpha-color-picker.js';
 import { rgbaToHsva, hsvaToRgba } from '../utils/convert.js';
 import { equalColorObjects } from '../utils/compare.js';
@@ -10,6 +15,20 @@ const colorModel: ColorModel<RgbaColor> = {
   equal: equalColorObjects,
   fromAttr: (color) => JSON.parse(color)
 };
+
+export interface RgbaBase {
+  addEventListener<T extends keyof ColorPickerEventMap<RgbaColor>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<RgbaColor>[T]>,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+
+  removeEventListener<T extends keyof ColorPickerEventMap<RgbaColor>>(
+    type: T,
+    listener: ColorPickerEventListener<ColorPickerEventMap<RgbaColor>[T]>,
+    options?: boolean | EventListenerOptions
+  ): void;
+}
 
 export class RgbaBase extends AlphaColorPicker<RgbaColor> {
   protected get colorModel(): ColorModel<RgbaColor> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,3 +39,21 @@ export interface ColorModel<T extends AnyColor> {
   equal: (first: T, second: T) => boolean;
   fromAttr: (attr: string) => T;
 }
+
+export type ColorChangedEvent<T> = CustomEvent<{ value: T }>;
+
+export interface ColorChangedEventListener<T> {
+  (evt: T): void;
+}
+
+export interface ColorChangedEventListenerObject<T> {
+  handleEvent(evt: T): void;
+}
+
+export interface ColorPickerEventMap<T> extends HTMLElementEventMap {
+  'color-changed': ColorChangedEvent<T>;
+}
+
+export type ColorPickerEventListener<T> =
+  | ColorChangedEventListener<T>
+  | ColorChangedEventListenerObject<T>;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,8 +40,6 @@ export interface ColorModel<T extends AnyColor> {
   fromAttr: (attr: string) => T;
 }
 
-export type ColorChangedEvent<T> = CustomEvent<{ value: T }>;
-
 export interface ColorChangedEventListener<T> {
   (evt: T): void;
 }
@@ -51,7 +49,7 @@ export interface ColorChangedEventListenerObject<T> {
 }
 
 export interface ColorPickerEventMap<T> extends HTMLElementEventMap {
-  'color-changed': ColorChangedEvent<T>;
+  'color-changed': CustomEvent<{ value: T }>;
 }
 
 export type ColorPickerEventListener<T> =


### PR DESCRIPTION
This change makes it possible to get following benefits when using TypeScript:

1. `color-changed` event name is listed in the event names autocomplete,
2. `event` parameter type is inferred based on the color-picker tag name.