### PR TITLE
refactor!: do not fire event on setting color

### DIFF
--- a/src/lib/components/color-picker.ts
+++ b/src/lib/components/color-picker.ts
@@ -11,7 +11,6 @@ import saturationCss from '../styles/saturation.js';
 const $isSame = Symbol('same');
 const $color = Symbol('color');
 const $hsva = Symbol('hsva');
-const $change = Symbol('change');
 const $update = Symbol('update');
 const $parts = Symbol('parts');
 
@@ -49,7 +48,7 @@ export abstract class ColorPicker<C extends AnyColor> extends HTMLElement {
     if (!this[$isSame](newColor)) {
       const newHsva = this.colorModel.toHsva(newColor);
       this[$update](newHsva);
-      this[$change](newColor);
+      this[$color] = newColor;
     }
   }
 
@@ -92,7 +91,8 @@ export abstract class ColorPicker<C extends AnyColor> extends HTMLElement {
       !equalColorObjects(newHsva, oldHsva) &&
       !this[$isSame]((newColor = this.colorModel.fromHsva(newHsva)))
     ) {
-      this[$change](newColor);
+      this[$color] = newColor;
+      fire(this, 'color-changed', { value: newColor });
     }
   }
 
@@ -103,10 +103,5 @@ export abstract class ColorPicker<C extends AnyColor> extends HTMLElement {
   private [$update](hsva: HsvaColor): void {
     this[$hsva] = hsva;
     this[$parts].forEach((part) => part.update(hsva));
-  }
-
-  private [$change](value: C): void {
-    this[$color] = value;
-    fire(this, 'color-changed', { value });
   }
 }

--- a/src/test/color-picker.test.ts
+++ b/src/test/color-picker.test.ts
@@ -85,50 +85,11 @@ describe('hex-color-picker', () => {
       expect(picker.getAttribute('color')).to.equal(null);
     });
 
-    it('should fire color-change event when property changes', () => {
+    it('should not fire color-changed event when property changes', () => {
       const spy = sinon.spy();
       picker.addEventListener('color-changed', spy);
       picker.color = '#123';
-      expect(spy.callCount).to.equal(1);
-    });
-
-    it('should not fire color-change event for same HEX property', () => {
-      const spy = sinon.spy();
-      picker.addEventListener('color-changed', spy);
-      picker.color = '#cccccc';
-      expect(spy.callCount).to.equal(0);
-    });
-  });
-
-  describe('color-changed event', () => {
-    afterEach(() => {
-      document.body.removeChild(picker);
-    });
-
-    it('should fire when component is attached', () => {
-      const spy = sinon.spy();
-      picker = document.createElement('hex-color-picker');
-      picker.addEventListener('color-changed', spy);
-      document.body.appendChild(picker);
-      expect(spy.callCount).to.equal(1);
-    });
-  });
-
-  describe('event propagation', () => {
-    let div: HTMLDivElement;
-
-    afterEach(() => {
-      document.body.removeChild(div);
-    });
-
-    it('should fire when component is attached', () => {
-      div = document.createElement('div');
-      const spy = sinon.spy();
-      picker = document.createElement('hex-color-picker');
-      div.addEventListener('color-changed', spy);
-      document.body.appendChild(div);
-      div.appendChild(picker);
-      expect(spy.callCount).to.equal(1);
+      expect(spy.called).to.be.false;
     });
   });
 
@@ -158,18 +119,11 @@ describe('hex-color-picker', () => {
       expect(picker.color).to.equal('#ccc');
     });
 
-    it('should fire color-change event when attribute changes', () => {
+    it('should not fire color-changed event when attribute changes', () => {
       const spy = sinon.spy();
       picker.addEventListener('color-changed', spy);
       picker.setAttribute('color', '#123');
-      expect(spy.callCount).to.equal(1);
-    });
-
-    it('should not fire color-change event for same HEX attribute', () => {
-      const spy = sinon.spy();
-      picker.addEventListener('color-changed', spy);
-      picker.setAttribute('color', '#448888');
-      expect(spy.callCount).to.equal(0);
+      expect(spy.called).to.be.false;
     });
   });
 


### PR DESCRIPTION
This is a breaking change aiming to align the implementation with [Custom Elements best practices](https://web.dev/custom-elements-best-practices/#events):

> Dispatching an event in response to a host setting a property is superfluous (the host knows the current state because it just set it). Dispatching events in response to a host setting a property may cause infinite loops with data binding systems.

From now on, `color-changed` event is only fired when color is picked by the user.
It will NOT be fired on setting `color` as a property or attribute on the component.

Fixes #64
Closes #70