### PR TITLE
fix: center pointer fill using flexbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     },
     {
       "path": "rgba-color-picker.js",
-      "limit": "2.9 KB"
+      "limit": "2.95 KB"
     },
     {
       "path": "rgba-string-color-picker.js",

--- a/src/lib/styles/color-picker.css
+++ b/src/lib/styles/color-picker.css
@@ -32,6 +32,9 @@
   box-sizing: border-box;
   width: 28px;
   height: 28px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   transform: translate(-50%, -50%);
   background-color: #fff;
   border: 2px solid #fff;
@@ -42,11 +45,8 @@
 [part$='pointer']::after {
   display: block;
   content: '';
-  position: absolute;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
+  width: 100%;
+  height: 100%;
   border-radius: inherit;
   background-color: currentColor;
 }

--- a/src/lib/styles/color-picker.css
+++ b/src/lib/styles/color-picker.css
@@ -33,8 +33,7 @@
   width: 28px;
   height: 28px;
   display: flex;
-  justify-content: center;
-  align-items: center;
+  place-content: center center;
   transform: translate(-50%, -50%);
   background-color: #fff;
   border: 2px solid #fff;

--- a/src/lib/styles/color-picker.css
+++ b/src/lib/styles/color-picker.css
@@ -43,7 +43,6 @@
 }
 
 [part$='pointer']::after {
-  display: block;
   content: '';
   width: 100%;
   height: 100%;


### PR DESCRIPTION
Fixes #57

Changed to use `display: flex` instead of `position: absolute` - inspired by https://github.com/omgovich/react-colorful/pull/175