### PR TITLE
feat: add Web Types support for IntelliJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ hex-input.js
 *.d.ts
 *.map
 custom-elements.json
+web-types.json
+web-types.lit.json

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "*.js.map",
     "hex-input.js",
     "*-color-picker.js",
-    "custom-elements.json"
+    "custom-elements.json",
+    "web-types.json",
+    "web-types.lit.json"
   ],
   "exports": {
     ".": "./hex-color-picker.js",
@@ -63,7 +65,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "analyze": "cem analyze --globs '*.js' 'lib/components/*.js' 'lib/entrypoints/*.js'",
+    "analyze": "cem analyze --globs '*.js' 'lib/components/*.js' 'lib/entrypoints/*.js' && node ./scripts/build-web-types.cjs",
     "build": "npm run styles && tsc",
     "deploy": "npm run dist && gh-pages -d dist",
     "dev": "npm run watch & npm run serve",
@@ -199,5 +201,9 @@
     "throttle-debounce": "^5.0.0",
     "tsc-watch": "^5.0.3",
     "typescript": "^4.7.4"
-  }
+  },
+  "web-types": [
+    "web-types.json",
+    "web-types.lit.json"
+  ]
 }

--- a/scripts/build-web-types.cjs
+++ b/scripts/build-web-types.cjs
@@ -1,0 +1,148 @@
+const path = require('path');
+const fs = require('fs');
+
+const PLAIN_WEB_TYPES_FILE = 'web-types.json';
+const LIT_WEB_TYPES_FILE = 'web-types.lit.json';
+
+function loadAnalysis() {
+  const analysisPath = path.resolve('./custom-elements.json');
+  try {
+    return JSON.parse(fs.readFileSync(analysisPath, 'utf8'));
+  } catch (e) {
+    throw new Error(
+      `Could not find "custom-elements.json". Make sure to run the CEM Analyzer before generating web-types.`
+    );
+  }
+}
+
+function getElementData(moduleInfo) {
+  const elementInfo = moduleInfo.declarations[0];
+
+  return {
+    name: moduleInfo.exports.find((entry) => entry.kind === 'custom-element-definition').name,
+    description: elementInfo.description,
+    properties: elementInfo.members.filter((member) => member.kind === 'field' && !!member.type),
+    attributes: elementInfo.attributes.filter((attribute) => !!attribute.type),
+    events: elementInfo.events
+  };
+}
+
+function createPlainElementDefinition(elementData) {
+  const attributes = elementData.attributes.map((attribute) => ({
+    name: attribute.name,
+    description: attribute.description,
+    value: {
+      type: [attribute.type.text]
+    }
+  }));
+
+  const properties = elementData.properties.map((prop) => ({
+    name: prop.name,
+    description: prop.description,
+    value: {
+      type: [prop.type.text]
+    }
+  }));
+
+  const events = elementData.events.map((event) => ({
+    name: event.name,
+    description: event.description
+  }));
+
+  return {
+    name: elementData.name,
+    description: elementData.description,
+    attributes,
+    js: {
+      properties,
+      events
+    }
+  };
+}
+
+function createPlainWebTypes(packageJson, packageModules) {
+  return {
+    $schema: 'https://json.schemastore.org/web-types',
+    name: packageJson.name,
+    version: packageJson.version,
+    'description-markup': 'markdown',
+    contributions: {
+      html: {
+        elements: packageModules.map((entry) => createPlainElementDefinition(getElementData(entry)))
+      }
+    }
+  };
+}
+
+function createLitElementDefinition(elementData) {
+  const propertyAttributes = elementData.properties.map((prop) => ({
+    name: `.${prop.name}`,
+    description: prop.description,
+    value: {
+      kind: 'expression'
+    }
+  }));
+
+  const eventAttributes = elementData.events.map((event) => ({
+    name: `@${event.name}`,
+    description: event.description,
+    value: {
+      kind: 'expression'
+    }
+  }));
+
+  return {
+    name: elementData.name,
+    description: elementData.description,
+    // Declare as extension to plain web type, this also means we don't have to
+    // repeat the same stuff from the plain web-types.json again
+    extension: true,
+    // IntelliJ does not understand Lit template syntax, so
+    // effectively everything has to be declared as attribute
+    attributes: [...propertyAttributes, ...eventAttributes]
+  };
+}
+
+function createLitWebTypes(packageJson, modules) {
+  return {
+    $schema: 'https://json.schemastore.org/web-types',
+    name: packageJson.name,
+    version: packageJson.version,
+    'description-markup': 'markdown',
+    framework: 'lit',
+    'framework-config': {
+      'enable-when': {
+        'node-packages': ['lit']
+      }
+    },
+    contributions: {
+      html: {
+        elements: modules.map((entry) => createLitElementDefinition(getElementData(entry)))
+      }
+    }
+  };
+}
+
+/**
+ * Create Web-Types definitions to enable IntelliJ IDEA code completion.
+ * The definitions are split into two files, one containing "plain" types
+ * for the web component, including attributes, properties and events.
+ * The other file contains Lit-specific bindings, to bind properties,
+ * attributes and events through their respective Lit attribute syntax.
+ */
+function buildWebTypes() {
+  const analysis = loadAnalysis();
+
+  const packageJson = JSON.parse(fs.readFileSync(`./package.json`, 'utf8'));
+  const entrypoints = analysis.modules.filter((el) => !el.path.startsWith('lib'));
+
+  const plainWebTypes = createPlainWebTypes(packageJson, entrypoints);
+  const plainWebTypesJson = JSON.stringify(plainWebTypes, null, 2);
+  fs.writeFileSync(PLAIN_WEB_TYPES_FILE, plainWebTypesJson, 'utf8');
+
+  const litWebTypes = createLitWebTypes(packageJson, entrypoints);
+  const litWebTypesJson = JSON.stringify(litWebTypes, null, 2);
+  fs.writeFileSync(path.join(LIT_WEB_TYPES_FILE), litWebTypesJson, 'utf8');
+}
+
+buildWebTypes();


### PR DESCRIPTION
Add support for the [Web-Types standard](https://github.com/JetBrains/web-types) for documenting web component libraries used by IntelliJ.
This adds auto-complete support for all included components when using them in HTML or Lit templates:

![web-types](https://user-images.githubusercontent.com/10589913/181750886-68a5841d-2c1d-48e7-94cc-1263375b13f0.png)

