### PR TITLE
chore: add esm.sh CDN example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Or use one of the following content delivery networks:
 <script type="module" src="https://jspm.dev/vanilla-colorful"></script>
 ```
 
+[ESM CDN](https://esm.sh):
+
+```html
+<script type="module" src="https://esm.sh/vanilla-colorful"></script>
+```
+
 ## Usage
 
 ```html


### PR DESCRIPTION
Added an example of importing the component from https://esm.sh which is a yet another ESM friendly CDN.