### PR TITLE
refactor: use substring instead of substr

### DIFF
--- a/src/lib/entrypoints/hex-input.ts
+++ b/src/lib/entrypoints/hex-input.ts
@@ -5,7 +5,7 @@ import { tpl } from '../utils/dom.js';
 const template = tpl('<slot><input part="input" spellcheck="false"></slot>');
 
 // Escapes all non-hexadecimal characters including "#"
-const escape = (hex: string) => hex.replace(/([^0-9A-F]+)/gi, '').substr(0, 6);
+const escape = (hex: string) => hex.replace(/([^0-9A-F]+)/gi, '').substring(0, 6);
 
 const $color = Symbol('color');
 const $saved = Symbol('saved');

--- a/src/lib/utils/convert.ts
+++ b/src/lib/utils/convert.ts
@@ -14,7 +14,7 @@ const angleUnits: Record<string, number> = {
 export const hexToHsva = (hex: string): HsvaColor => rgbaToHsva(hexToRgba(hex));
 
 export const hexToRgba = (hex: string): RgbaColor => {
-  if (hex[0] === '#') hex = hex.substr(1);
+  if (hex[0] === '#') hex = hex.substring(1);
 
   if (hex.length < 6) {
     return {
@@ -26,9 +26,9 @@ export const hexToRgba = (hex: string): RgbaColor => {
   }
 
   return {
-    r: parseInt(hex.substr(0, 2), 16),
-    g: parseInt(hex.substr(2, 2), 16),
-    b: parseInt(hex.substr(4, 2), 16),
+    r: parseInt(hex.substring(0, 2), 16),
+    g: parseInt(hex.substring(2, 4), 16),
+    b: parseInt(hex.substring(4, 6), 16),
     a: hex.length === 8 ? round(parseInt(hex.substring(6, 8), 16) / 255, 2) : 1
   };
 };


### PR DESCRIPTION
## Description

Same as https://github.com/omgovich/react-colorful/pull/182

Removed the `substr` method usage, as it's deprecated:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr