### PR TITLE
feat: add prefixed property to hex-input

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,12 @@ hex-color-picker::part(hue-pointer) {
 `<hex-input>` renders an unstyled `<input>` element inside a slot and exposes it for styling using
 `part`. You can also pass your own `<input>` element as a child if you want to fully configure it.
 
-| Property | Default | Description                                  |
-| -------- | ------- | -------------------------------------------- |
-| `alpha`  | `false` | Allows `#rgba` and `#rrggbbaa` color formats |
+In addition to `color` property, `<hex-input>` supports the following boolean properties:
+
+| Property   | Default | Description                                  |
+| ---------- | ------- | -------------------------------------------- |
+| `alpha`    | `false` | Allows `#rgba` and `#rrggbbaa` color formats |
+| `prefixed` | `false` | Enables `#` prefix displaying                |
 
 ## Base classes
 

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     },
     {
       "path": "hex-input.js",
-      "limit": "1 KB"
+      "limit": "1.1 KB"
     }
   ],
   "sideEffects": [

--- a/src/hex-input.ts
+++ b/src/hex-input.ts
@@ -9,6 +9,8 @@ import { HexInputBase } from './lib/entrypoints/hex-input.js';
  * @attr {string} color - Selected color in HEX format.
  * @prop {boolean} alpha - When true, `#rgba` and `#rrggbbaa` color formats are allowed.
  * @attr {boolean} alpha - Allows `#rgba` and `#rrggbbaa` color formats.
+ * @prop {boolean} prefixed - When true, `#` prefix is displayed in the input.
+ * @attr {boolean} prefixed - Enables `#` prefix displaying.
  *
  * @fires color-changed - Event fired when color is changed.
  *

--- a/src/test/hex-input.test.ts
+++ b/src/test/hex-input.test.ts
@@ -14,16 +14,18 @@ describe('hex-input', () => {
   }
 
   describe('lazy upgrade', () => {
-    it('should work with color property set before upgrade', async () => {
+    it('should work with all properties set before upgrade', async () => {
       const element = document.createElement('hex-input');
       document.body.appendChild(element);
       element.alpha = true;
+      element.prefixed = true;
       element.color = '#123';
       await import('../hex-input');
       expect(element.color).to.equal('#123');
       expect(element.alpha).to.be.true;
+      expect(element.prefixed).to.be.true;
       target = getTarget(element);
-      expect(target.value).to.equal('123');
+      expect(target.value).to.equal('#123');
       document.body.removeChild(element);
     });
   });
@@ -330,6 +332,60 @@ describe('hex-input', () => {
         await sendKeys({ press: '6' });
         target.dispatchEvent(new Event('blur'));
 
+        expect(target.value).to.equal('112233');
+      });
+    });
+  });
+
+  describe('prefixed', () => {
+    describe('property', () => {
+      beforeEach(async () => {
+        input = await fixture(html`<hex-input></hex-input>`);
+        input.prefixed = true;
+        input.color = '#112233';
+        target = getTarget(input);
+      });
+
+      it('should set prefixed attribute when prefixed property is set', () => {
+        expect(input.hasAttribute('prefixed')).to.be.true;
+      });
+
+      it('should set # to the input when prefixed property is set', () => {
+        expect(target.value).to.equal('#112233');
+      });
+
+      it('should remove prefixed attribute when prefixed property is set to false', () => {
+        input.prefixed = false;
+        expect(input.hasAttribute('prefixed')).to.be.false;
+      });
+
+      it('should remove # from the input when prefixed property is set to false', () => {
+        input.prefixed = false;
+        expect(target.value).to.equal('112233');
+      });
+    });
+
+    describe('attribute', () => {
+      beforeEach(async () => {
+        input = await fixture(html`<hex-input color="#112233" prefixed></hex-input>`);
+        target = getTarget(input);
+      });
+
+      it('should set prefixed to true when prefixed attribute is set', () => {
+        expect(input.prefixed).to.be.true;
+      });
+
+      it('should set # to the input when prefixed attribute is set', () => {
+        expect(target.value).to.equal('#112233');
+      });
+
+      it('should set prefixed to false when prefixed attribute is removed', () => {
+        input.removeAttribute('prefixed');
+        expect(input.prefixed).to.be.false;
+      });
+
+      it('should remove # from the input when prefixed attribute is removed', () => {
+        input.removeAttribute('prefixed');
         expect(target.value).to.equal('112233');
       });
     });


### PR DESCRIPTION
## Description

Added `prefixed` property to`<hex-input>` that enables displaying `#` prefix in the `<input>`.
See also https://github.com/omgovich/react-colorful/pull/146 where this has been originally implemented.