### PR TITLE
refactor: simplify render helper to reduce size

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     },
     {
       "path": "hsl-string-color-picker.js",
-      "limit": "2.7 KB"
+      "limit": "2.6 KB"
     },
     {
       "path": "hsla-color-picker.js",
@@ -184,7 +184,7 @@
     },
     {
       "path": "hsv-string-color-picker.js",
-      "limit": "2.7 KB"
+      "limit": "2.6 KB"
     },
     {
       "path": "hsva-color-picker.js",
@@ -204,7 +204,7 @@
     },
     {
       "path": "rgba-color-picker.js",
-      "limit": "2.95 KB"
+      "limit": "2.9 KB"
     },
     {
       "path": "rgba-string-color-picker.js",

--- a/src/lib/components/color-picker.ts
+++ b/src/lib/components/color-picker.ts
@@ -1,5 +1,5 @@
 import { equalColorObjects } from '../utils/compare.js';
-import { fire, tpl } from '../utils/dom.js';
+import { fire, render } from '../utils/dom.js';
 import type { AnyColor, ColorModel, HsvaColor } from '../types';
 import { Hue } from './hue.js';
 import { Saturation } from './saturation.js';
@@ -54,9 +54,8 @@ export abstract class ColorPicker<C extends AnyColor> extends HTMLElement {
 
   constructor() {
     super();
-    const template = tpl(`<style>${this[$css].join('')}</style>`);
     const root = this.attachShadow({ mode: 'open' });
-    root.appendChild(template.content.cloneNode(true));
+    render(root, `<style>${this[$css].join('')}</style>`);
     root.addEventListener('move', this);
     this[$parts] = this[$sliders].map((slider) => new slider(root));
   }

--- a/src/lib/components/slider.ts
+++ b/src/lib/components/slider.ts
@@ -1,5 +1,5 @@
 import type { HsvaColor } from '../types.js';
-import { fire, tpl } from '../utils/dom.js';
+import { fire, render } from '../utils/dom.js';
 import { clamp } from '../utils/math.js';
 
 export interface Offset {
@@ -81,10 +81,10 @@ export abstract class Slider {
   declare xy: boolean;
 
   constructor(root: ShadowRoot, part: string, aria: string, xy: boolean) {
-    const template = tpl(
+    render(
+      root,
       `<div role="slider" tabindex="0" part="${part}" ${aria}><div part="${part}-pointer"></div></div>`
     );
-    root.appendChild(template.content.cloneNode(true));
 
     const el = root.querySelector(`[part=${part}]`) as HTMLElement;
     el.addEventListener('mousedown', this);

--- a/src/lib/entrypoints/hex-input.ts
+++ b/src/lib/entrypoints/hex-input.ts
@@ -1,8 +1,6 @@
 import type { ColorPickerEventListener, ColorPickerEventMap } from '../types';
 import { validHex } from '../utils/validate.js';
-import { tpl } from '../utils/dom.js';
-
-const template = tpl('<slot><input part="input" spellcheck="false"></slot>');
+import { render } from '../utils/dom.js';
 
 // Escapes all non-hexadecimal characters including "#"
 const escape = (hex: string, alpha: boolean) =>
@@ -85,7 +83,7 @@ export class HexInputBase extends HTMLElement {
     super();
 
     const root = this.attachShadow({ mode: 'open' });
-    root.appendChild(template.content.cloneNode(true));
+    render(root, '<slot><input part="input" spellcheck="false"></slot>');
     const slot = root.firstElementChild as HTMLSlotElement;
     slot.addEventListener('slotchange', () => this[$init](root));
   }

--- a/src/lib/utils/dom.ts
+++ b/src/lib/utils/dom.ts
@@ -1,13 +1,13 @@
 const cache: Record<string, HTMLTemplateElement> = {};
 
-export const tpl = (html: string): HTMLTemplateElement => {
+export const render = (root: ShadowRoot, html: string): void => {
   let template = cache[html];
   if (!template) {
     template = document.createElement('template');
     template.innerHTML = html;
     cache[html] = template;
   }
-  return template;
+  root.appendChild(template.content.cloneNode(true));
 };
 
 export const fire = (target: HTMLElement, type: string, detail: Record<string, unknown>): void => {


### PR DESCRIPTION
## Description

Changed the helper used to render the template content, which causes the following bundle size reduction:

  
```diff
hex-alpha-color-picker.js
  Size limit: 3.15 kB
-  Size:       3.12 kB with all dependencies, minified and gzipped
+  Size:       3.11 kB with all dependencies, minified and gzipped

  hex-color-picker.js
  Size limit: 2.8 kB
-  Size:       2.8 kB with all dependencies, minified and gzipped
+  Size:       2.79 kB with all dependencies, minified and gzipped 

  hsl-color-picker.js
  Size limit: 2.5 kB
-  Size:       2.45 kB with all dependencies, minified and gzipped
+  Size:       2.44 kB with all dependencies, minified and gzipped

  hsl-string-color-picker.js
  Size limit: 2.7 kB
-  Size:       2.62 kB with all dependencies, minified and gzipped
+  Size:       2.6 kB with all dependencies, minified and gzipped 

  hsla-color-picker.js
  Size limit: 2.8 kB
-  Size:       2.76 kB with all dependencies, minified and gzipped
+  Size:       2.74 kB with all dependencies, minified and gzippe

  hsla-string-color-picker.js
  Size limit: 2.95 kB
-  Size:       2.94 kB with all dependencies, minified and gzipped
+  Size:       2.74 kB with all dependencies, minified and gzipped

  hsv-color-picker.js
  Size limit: 2.5 kB
-  Size:       2.44 kB with all dependencies, minified and gzipped
+  Size:       2.42 kB with all dependencies, minified and gzipped

  hsv-string-color-picker.js
  Size limit: 2.7 kB
-  Size:       2.62 kB with all dependencies, minified and gzipped
+  Size:       2.6 kB with all dependencies, minified and gzipped

  hsva-color-picker.js
  Size limit: 2.75 kB
-  Size:       2.74 kB with all dependencies, minified and gzipped
+  Size:       2.73 kB with all dependencies, minified and gzipped

  hsva-string-color-picker.js
  Size limit: 2.95 kB
-  Size:       2.94 kB with all dependencies, minified and gzipped
+  Size:       2.92 kB with all dependencies, minified and gzipped

  rgb-color-picker.js
  Size limit: 2.6 kB
-  Size:       2.59 kB with all dependencies, minified and gzipped
+  Size:       2.58 kB with all dependencies, minified and gzipped

  rgb-string-color-picker.js
  Size limit: 2.8 kB
-  Size:       2.75 kB with all dependencies, minified and gzipped
+  Size:       2.74 kB with all dependencies, minified and gzipped

  rgba-color-picker.js
  Size limit: 2.95 kB
-  Size:       2.9 kB  with all dependencies, minified and gzipped
+  Size:       2.88 kB with all dependencies, minified and gzipped

  rgba-string-color-picker.js
  Size limit: 3.1 kB
-  Size:       3.08 kB with all dependencies, minified and gzipped
+  Size:       3.06 kB with all dependencies, minified and gzipped
```