### PR TITLE
Move prefixed properties before unprefixed

### DIFF
--- a/src/lib/styles/color-picker.css
+++ b/src/lib/styles/color-picker.css
@@ -4,8 +4,8 @@
   position: relative;
   width: 200px;
   height: 200px;
-  user-select: none;
   -webkit-user-select: none;
+  user-select: none;
   cursor: default;
 }
 
@@ -16,8 +16,8 @@
 [role='slider'] {
   position: relative;
   touch-action: none;
-  user-select: none;
   -webkit-user-select: none;
+  user-select: none;
   outline: none;
 }
 


### PR DESCRIPTION
Prefixed properties are supposed to be followed by unprefixed properties to ensure that modern browsers use the most relevant and standard-compliant implementation if they still support both. I understand that it’s not super relevant, but just for the sake of spreading the knowledge, I’ll give it a go :)

For more details on the matter, see Eric Meyer’s [Prefix or Posthack](https://alistapart.com/article/prefix-or-posthack/#section6) article. Oh my, it’s 14 years old!